### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Create a report to help us fix broken features
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug, what's wrong, and what you expect:**
+
+A clear and concise description of what the bug is. 
+
+A clear and concise description of what you expected to happen.
+
+-----
+
+**To Reproduce**
+
+Please include a code snippet to reproduce the bug in the block below:
+
+```py
+# Insert code here
+
+```
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+-----
+
+**System Information:**
+ Please run the following code wherever you are experiencing the bug and paste the output below. This report helps us track down bugs and it is critical to addressing your bug:
+
+```py
+# Get system info
+import pyvista as pv
+print(pv.Report())
+```
+
+```txt
+# Paste system info here
+
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Questions and Discussions
+    url: https://github.com/pyvista/pyvista-tutorial/discussions
+    about: For general questions and discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Request that a feature be added to pyvista-tutorial
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe what feature you would like added.**
+
+A clear and concise description of what you would like added.
+
+If you are requesting a feature from PyVista document, please include links to the PyVista document, example, or class definition.
+
+Feel free to include pseudocode or screenshots of the requested outcome.
+
+-----


### PR DESCRIPTION
Add issue templates.
Referencing https://github.com/pyvista/pyvista/tree/main/.github/ISSUE_TEMPLATE .