### PR TITLE
Fix the link to the binder

### DIFF
--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -157,5 +157,5 @@ PyVista.
 |binder|
 
 .. |binder| image:: https://static.mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/pyvista/pyvista-examples/master
+   :target: https://mybinder.org/v2/gh/pyvista/pyvista-tutorial/gh-pages?urlpath=lab/tree/notebooks
    :alt: Launch on Binder


### PR DESCRIPTION
### Overview

Fix the link to the binder. See https://github.com/pyvista/pyvista-tutorial/pull/48 .

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
