### PR TITLE
Remove non-Trame Jupyter backends

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: codespell
     args: [
-      "doc examples examples_flask pyvista tests",
+      "doc tutorial",
       "*.py *.rst *.md",
     ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ SHELL ["/bin/bash", "-c"]
 COPY . $HOME
 
 RUN pip install pyvista
-RUN pip install flask==2.1.2
 RUN pip install pyinstaller==5.1
 RUN pip install sphinx
 RUN pip install jupyterlab

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ RUN pip install flask==2.1.2
 RUN pip install pyinstaller==5.1
 RUN pip install sphinx
 RUN pip install jupyterlab
-RUN pip install ipyvtklink
-RUN pip install pythreejs
 RUN pip install tqdm
 RUN pip install imageio>=2.5.0
 RUN pip install imageio-ffmpeg
 RUN pip install matplotlib
 RUN pip install cmocean
+RUN pip install trame

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -68,13 +68,13 @@ the following packages:
 
       .. code::
 
-         pip install jupyterlab trame
+         pip install jupyterlab trame ipywidgets
 
    .. tab:: conda
 
       .. code::
 
-         conda install -c conda-forge jupyterlab trame
+         conda install -c conda-forge jupyterlab trame ipywidgets
 
 
 You can then plot using Jupyterlab or Jupyter Notebook interactively with one of three backends:
@@ -84,7 +84,7 @@ You can then plot using Jupyterlab or Jupyter Notebook interactively with one of
 
       import pyvista as pv
       pv.set_plot_theme('document')
-      pv.global_theme.jupyter_backend = 'static'
+      pv.set_jupyter_backend('static')
 
    .. jupyter-execute::
 
@@ -115,7 +115,7 @@ Visit the `PyVista on Colab  <https://colab.research.google.com/drive/15REd98bzn
 
    import pyvista
 
-   pyvista.global_theme.jupyter_backend = 'static'
+   pyvista.set_jupyter_backend('static')
    pyvista.global_theme.notebook = True
    pyvista.start_xvfb()
 

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -104,7 +104,7 @@ You can then plot using Jupyterlab or Jupyter Notebook interactively with one of
 
          import pyvista as pv
          from pyvista import examples
-         pv.global_theme.jupyter_backend = 'panel'
+         pv.global_theme.jupyter_backend = 'trame'
 
          dataset = examples.download_lidar()
          dataset.plot(cmap="gist_earth")

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -68,13 +68,13 @@ the following packages:
 
       .. code::
 
-         pip install jupyterlab pythreejs ipyvtklink panel
+         pip install jupyterlab trame
 
    .. tab:: conda
 
       .. code::
 
-         conda install -c conda-forge jupyterlab pythreejs ipyvtklink panel
+         conda install -c conda-forge jupyterlab trame
 
 
 You can then plot using Jupyterlab or Jupyter Notebook interactively with one of three backends:

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -109,13 +109,13 @@ You can then plot using Jupyterlab or Jupyter Notebook interactively with one of
          dataset = examples.download_lidar()
          dataset.plot(cmap="gist_earth")
 
-   .. tab:: pythreejs
+   .. tab:: trame
 
       .. jupyter-execute::
 
          import pyvista as pv
          from pyvista import examples
-         pv.global_theme.jupyter_backend = 'pythreejs'
+         pv.global_theme.jupyter_backend = 'trame'
          pv.global_theme.window_size = (700, 300)
          pv.global_theme.anti_aliasing = 'fxaa'
 

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -81,7 +81,7 @@ You can then plot using Jupyterlab or Jupyter Notebook interactively with one of
 
 .. tabs::
 
-   .. tab:: ipyvtklink
+   .. tab:: trame
 
       .. jupyter-execute::
          :hide-code:

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -79,48 +79,20 @@ the following packages:
 
 You can then plot using Jupyterlab or Jupyter Notebook interactively with one of three backends:
 
-.. tabs::
+   .. jupyter-execute::
+      :hide-code:
 
-   .. tab:: trame
+      import pyvista as pv
+      pv.set_plot_theme('document')
+      pv.global_theme.jupyter_backend = 'static'
 
-      .. jupyter-execute::
-         :hide-code:
+   .. jupyter-execute::
 
-         import pyvista as pv
-         pv.set_plot_theme('document')
-         pv.global_theme.jupyter_backend = 'static'
+      import pyvista as pv
+      from pyvista import examples
 
-      .. jupyter-execute::
-
-         import pyvista as pv
-         from pyvista import examples
-
-         dataset = examples.download_lucy()
-         dataset.plot(smooth_shading=True, color='white')
-
-   .. tab:: panel
-
-      .. jupyter-execute::
-
-         import pyvista as pv
-         from pyvista import examples
-         pv.global_theme.jupyter_backend = 'trame'
-
-         dataset = examples.download_lidar()
-         dataset.plot(cmap="gist_earth")
-
-   .. tab:: trame
-
-      .. jupyter-execute::
-
-         import pyvista as pv
-         from pyvista import examples
-         pv.global_theme.jupyter_backend = 'trame'
-         pv.global_theme.window_size = (700, 300)
-         pv.global_theme.anti_aliasing = 'fxaa'
-
-         dataset = examples.download_cad_model()
-         dataset.plot(background='w', pbr=True, metallic=0.6, roughness=0.4, split_sharp_edges=True)
+      dataset = examples.download_lucy()
+      dataset.plot(smooth_shading=True, color='white')
 
 
 .. _colab:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,13 @@ cmocean
 flask==2.2.2
 imageio>=2.5.0
 imageio-ffmpeg
-ipyvtklink
 jupyterlab
 matplotlib
 pyinstaller==5.6.2
 pyqt5
-pythreejs
 pyvista
 pyvistaqt
 QtPy
 sphinx
 tqdm
+trame

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cmocean
-flask==2.3.2
 imageio>=2.5.0
 imageio-ffmpeg
 jupyterlab
@@ -11,4 +10,7 @@ pyvistaqt
 QtPy
 sphinx
 tqdm
-trame
+trame>=2.5.0
+trame-client>=2.9.4
+trame-server>=2.11.4
+trame-vtk>=2.5.4

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,7 +3,6 @@ colorcet==3.0.1
 imageio>=2.5.0
 imageio-ffmpeg==0.4.7
 ipygany==0.5.0
-ipyvtklink==0.2.3
 jupyter_sphinx==0.4.0
 jupyterlab==3.5.0
 lxml==4.9.1
@@ -13,13 +12,10 @@ mypy==0.982
 mypy-extensions==0.4.3
 numpydoc==1.5.0
 osmnx==1.2.2
-panel==0.14.1
-param==1.12.2  # due to panel bug
 pydata-sphinx-theme==0.11.0
 pypandoc==1.10
 pyqt5
 pytest-sphinx==0.5.0
-pythreejs==2.4.1
 pyvistaqt
 QtPy
 scipy==1.9.3
@@ -32,6 +28,10 @@ sphinx-tabs
 sphinx_design==0.3.0
 sphinxcontrib-websupport==1.2.4
 sphinxcontrib.asciinema
+trame==2.2.6
+trame-client==2.5.1
+trame-server==2.8.1
+trame-vtk==2.0.17
 trimesh==3.15.8
 typed-ast==1.5.4
 typing_extensions==4.4.0

--- a/tutorial/00_intro/README.rst
+++ b/tutorial/00_intro/README.rst
@@ -90,7 +90,7 @@ simple surface mesh:
 
    # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
+   pyvista.set_jupyter_backend('static')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.window_size = [600, 400]
    pyvista.global_theme.axes.show = False

--- a/tutorial/00_intro/README.rst
+++ b/tutorial/00_intro/README.rst
@@ -88,9 +88,9 @@ simple surface mesh:
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.window_size = [600, 400]
    pyvista.global_theme.axes.show = False

--- a/tutorial/01_basic/README.rst
+++ b/tutorial/01_basic/README.rst
@@ -32,9 +32,9 @@ Here's a very basic dataset you can download.
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/01_basic/README.rst
+++ b/tutorial/01_basic/README.rst
@@ -34,7 +34,6 @@ Here's a very basic dataset you can download.
 
    # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/01_basic/a_lesson_basic.py
+++ b/tutorial/01_basic/a_lesson_basic.py
@@ -10,10 +10,10 @@ using the `pyvista.examples.downloads
 module and external files.
 """
 
-# Configure for panel
+# Configure for trame
 import pyvista
 
-pyvista.set_jupyter_backend('panel')
+pyvista.set_jupyter_backend('trame')
 pyvista.set_plot_theme('document')
 
 

--- a/tutorial/01_basic/a_lesson_basic.py
+++ b/tutorial/01_basic/a_lesson_basic.py
@@ -13,7 +13,6 @@ module and external files.
 # Configure for trame
 import pyvista
 
-pyvista.set_jupyter_backend('trame')
 pyvista.set_plot_theme('document')
 
 

--- a/tutorial/02_mesh/README.rst
+++ b/tutorial/02_mesh/README.rst
@@ -53,9 +53,9 @@ You can create one by defining a 2D array of Cartesian coordinates like so:
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/02_mesh/README.rst
+++ b/tutorial/02_mesh/README.rst
@@ -53,9 +53,7 @@ You can create one by defining a 2D array of Cartesian coordinates like so:
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/02_mesh/exercises/e_read-file.py
+++ b/tutorial/02_mesh/exercises/e_read-file.py
@@ -23,7 +23,7 @@ help(pv.read)
 ###############################################################################
 # PyVista supports a wide variety of file formats. The supported file
 # extensions are listed in an internal function:
-help(pv.utilities.reader.get_reader)
+help(pv.core.utilities.reader.get_reader)
 
 
 ###############################################################################

--- a/tutorial/02_mesh/soultions/e_read-file.py
+++ b/tutorial/02_mesh/soultions/e_read-file.py
@@ -25,7 +25,7 @@ help(pv.read)
 ###############################################################################
 # PyVista supports a wide variety of file formats. The supported file
 # extensions are listed in an internal function:
-help(pv.utilities.reader.get_reader)
+help(pv.core.utilities.reader.get_reader)
 
 
 ###############################################################################

--- a/tutorial/03_figures/README.rst
+++ b/tutorial/03_figures/README.rst
@@ -43,9 +43,9 @@ When plotting, users must first create a :class:`pyvista.Plotter` instance (much
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/03_figures/README.rst
+++ b/tutorial/03_figures/README.rst
@@ -45,7 +45,6 @@ When plotting, users must first create a :class:`pyvista.Plotter` instance (much
 
    # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/04_filters/README.rst
+++ b/tutorial/04_filters/README.rst
@@ -43,7 +43,6 @@ object:
 
    # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/04_filters/README.rst
+++ b/tutorial/04_filters/README.rst
@@ -41,9 +41,9 @@ object:
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/06_vtk/README.rst
+++ b/tutorial/06_vtk/README.rst
@@ -254,9 +254,9 @@ example:
 .. jupyter-execute::
    :hide-code:
 
-   # Configure for panel
+   # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('panel')
+   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/06_vtk/README.rst
+++ b/tutorial/06_vtk/README.rst
@@ -256,7 +256,6 @@ example:
 
    # Configure for trame
    import pyvista
-   pyvista.set_jupyter_backend('trame')
    pyvista.global_theme.background = 'white'
    pyvista.global_theme.axes.show = False
    pyvista.global_theme.smooth_shading = True

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -95,14 +95,14 @@ Will be rendered as:
 
 Likewise, output from PyVista that would normally be rendered within a notebook
 will be rendered in the output cell from the ``jupyter-execute`` directive. For
-example, here's a plot using the `pythreejs
-<https://github.com/jupyter-widgets/pythreejs>`_ backend::
+example, here's a plot using the `trame
+<https://github.com/jupyter-widgets/trame>`_ backend::
 
   .. jupyter-execute::
 
      from pyvista import examples
      dataset = examples.download_urn()
-     dataset.plot(color='tan', jupyter_backend='pythreejs', window_size=(700, 400))
+     dataset.plot(color='tan', jupyter_backend='trame', window_size=(700, 400))
 
 Which is rendered as:
 
@@ -110,7 +110,7 @@ Which is rendered as:
 
    from pyvista import examples
    dataset = examples.download_urn()
-   dataset.plot(color='tan', jupyter_backend='pythreejs', window_size=(700, 400))
+   dataset.plot(color='tan', jupyter_backend='trame', window_size=(700, 400))
 
 
 Using the ``Trame`` backend with PyVista
@@ -215,7 +215,7 @@ Which looks like:
 
 .. note::
    You have the option of choosing `trame <https://github.com/Kitware/trame>`_
-   or `pythreejs <https://github.com/jupyter-widgets/pythreejs>`_ as a backend,
+   or `trame <https://github.com/jupyter-widgets/trame>`_ as a backend,
    but you might find that `trame <https://github.com/Kitware/trame>`_ has
    better support as it's being actively developed.
 

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -115,7 +115,7 @@ Which is rendered as:
 
 Using the ``Trame`` backend with PyVista
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-PyVista supports the usage of the `trame <https://github.com/holoviz/trame>`_
+PyVista supports the usage of the `trame <https://github.com/Kitware/trame>`_
 library as a ``vtk.js`` jupyterlab plotting backend that can be utilized as
 either a standalone VTK viewer, or as a tightly integrated ``pyvista`` plotting
 backend.  For example, within a Jupyter notebook environment, you can pass
@@ -140,7 +140,7 @@ Which is shown within the documentation as:
 
 Examples and Usage
 ~~~~~~~~~~~~~~~~~~
-There are two ways to use `trame <https://github.com/holoviz/trame>`_ within
+There are two ways to use `trame <https://github.com/Kitware/trame>`_ within
 Jupyter notebooks.  You can use it on a plot by plot basis by setting the
 ``jupyter_backend`` in ``mesh.plot()``::
 
@@ -214,9 +214,9 @@ Which looks like:
 
 
 .. note::
-   You have the option of choosing `trame <https://github.com/holoviz/trame>`_
+   You have the option of choosing `trame <https://github.com/Kitware/trame>`_
    or `pythreejs <https://github.com/jupyter-widgets/pythreejs>`_ as a backend,
-   but you might find that `trame <https://github.com/holoviz/trame>`_ has
+   but you might find that `trame <https://github.com/Kitware/trame>`_ has
    better support as it's being actively developed.
 
 

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -113,7 +113,7 @@ Which is rendered as:
    dataset.plot(color='tan', jupyter_backend='pythreejs', window_size=(700, 400))
 
 
-Using the ``Panel`` backend with PyVista
+Using the ``Trame`` backend with PyVista
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PyVista supports the usage of the `trame <https://github.com/holoviz/trame>`_
 library as a ``vtk.js`` jupyterlab plotting backend that can be utilized as

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -115,32 +115,32 @@ Which is rendered as:
 
 Using the ``Panel`` backend with PyVista
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-PyVista supports the usage of the `panel <https://github.com/holoviz/panel>`_
+PyVista supports the usage of the `trame <https://github.com/holoviz/trame>`_
 library as a ``vtk.js`` jupyterlab plotting backend that can be utilized as
 either a standalone VTK viewer, or as a tightly integrated ``pyvista`` plotting
 backend.  For example, within a Jupyter notebook environment, you can pass
-``jupyter_backend='panel'`` to ``plot``, or ``Plotter.show`` to automatically
-enable plotting with Juptyer and ``panel``.
+``jupyter_backend='trame'`` to ``plot``, or ``Plotter.show`` to automatically
+enable plotting with Juptyer and ``trame``.
 
 For example, here's the ``PyVista`` logo::
 
    .. jupyter-execute::
 
       from pyvista import demos
-      demos.plot_logo(background='white', jupyter_backend='panel')
+      demos.plot_logo(background='white', jupyter_backend='trame')
 
 Which is shown within the documentation as:
 
 .. jupyter-execute::
 
    from pyvista import demos
-   demos.plot_logo(background='white', jupyter_backend='panel')
+   demos.plot_logo(background='white', jupyter_backend='trame')
 
 |
 
 Examples and Usage
 ~~~~~~~~~~~~~~~~~~
-There are two ways to use `panel <https://github.com/holoviz/panel>`_ within
+There are two ways to use `trame <https://github.com/holoviz/trame>`_ within
 Jupyter notebooks.  You can use it on a plot by plot basis by setting the
 ``jupyter_backend`` in ``mesh.plot()``::
 
@@ -154,7 +154,7 @@ Jupyter notebooks.  You can use it on a plot by plot basis by setting the
        point_cloud = pv.PolyData(dataset.points[::100])
        point_cloud['height'] = point_cloud.points[:, 2]
        point_cloud.plot(window_size=[500, 500],
-                        jupyter_backend='panel',
+                        jupyter_backend='trame',
                         cmap='jet',
                         point_size=2,
                         background='w')
@@ -171,7 +171,7 @@ And here's the resulting output in Sphinx:
     point_cloud = pv.PolyData(dataset.points[::100])
     point_cloud['height'] = point_cloud.points[:, 2]
     point_cloud.plot(window_size=[500, 500],
-                     jupyter_backend='panel',
+                     jupyter_backend='trame',
                      cmap='jet',
                      point_size=2,
                      background='w')
@@ -186,15 +186,15 @@ Or you can first hide code that sets up the plotting backend and global theme::
        import pyvista as pv
 
        # Set the global jupyterlab backend.  All plots from this point
-       # onward will use the ``panel`` backend and do not have to be
+       # onward will use the ``trame`` backend and do not have to be
        # specified in ``show``
-       pv.set_jupyter_backend('panel')
+       pv.set_jupyter_backend('trame')
 
 .. jupyter-execute::
    :hide-code:
 
    import pyvista as pv
-   pv.set_jupyter_backend('panel')
+   pv.set_jupyter_backend('trame')
 
 And now just directly execute ``plot`` on any dataset::
 
@@ -214,9 +214,9 @@ Which looks like:
 
 
 .. note::
-   You have the option of choosing `panel <https://github.com/holoviz/panel>`_
+   You have the option of choosing `trame <https://github.com/holoviz/trame>`_
    or `pythreejs <https://github.com/jupyter-widgets/pythreejs>`_ as a backend,
-   but you might find that `panel <https://github.com/holoviz/panel>`_ has
+   but you might find that `trame <https://github.com/holoviz/trame>`_ has
    better support as it's being actively developed.
 
 

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -96,7 +96,7 @@ Will be rendered as:
 Likewise, output from PyVista that would normally be rendered within a notebook
 will be rendered in the output cell from the ``jupyter-execute`` directive. For
 example, here's a plot using the `trame
-<https://github.com/jupyter-widgets/trame>`_ backend::
+<https://github.com/Kitware/trame>`_ backend::
 
   .. jupyter-execute::
 
@@ -215,7 +215,7 @@ Which looks like:
 
 .. note::
    You have the option of choosing `trame <https://github.com/Kitware/trame>`_
-   or `trame <https://github.com/jupyter-widgets/trame>`_ as a backend,
+   or `trame <https://github.com/Kitware/trame>`_ as a backend,
    but you might find that `trame <https://github.com/Kitware/trame>`_ has
    better support as it's being actively developed.
 

--- a/tutorial/07_sphinx/README.rst
+++ b/tutorial/07_sphinx/README.rst
@@ -154,7 +154,6 @@ Jupyter notebooks.  You can use it on a plot by plot basis by setting the
        point_cloud = pv.PolyData(dataset.points[::100])
        point_cloud['height'] = point_cloud.points[:, 2]
        point_cloud.plot(window_size=[500, 500],
-                        jupyter_backend='trame',
                         cmap='jet',
                         point_size=2,
                         background='w')
@@ -171,7 +170,6 @@ And here's the resulting output in Sphinx:
     point_cloud = pv.PolyData(dataset.points[::100])
     point_cloud['height'] = point_cloud.points[:, 2]
     point_cloud.plot(window_size=[500, 500],
-                     jupyter_backend='trame',
                      cmap='jet',
                      point_size=2,
                      background='w')
@@ -188,13 +186,11 @@ Or you can first hide code that sets up the plotting backend and global theme::
        # Set the global jupyterlab backend.  All plots from this point
        # onward will use the ``trame`` backend and do not have to be
        # specified in ``show``
-       pv.set_jupyter_backend('trame')
 
 .. jupyter-execute::
    :hide-code:
 
    import pyvista as pv
-   pv.set_jupyter_backend('trame')
 
 And now just directly execute ``plot`` on any dataset::
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
<img src="https://kitware.github.io/trame/logo.svg" alt="trame" title="trame" width="50">

This PR removes the deprecated Jupyter backend. They will all be replaced by [trame](https://kitware.github.io/trame/index.html) .

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- https://github.com/pyvista/pyvista/issues/3690