### PR TITLE
Remove Slack link and leave GitHub Discussion

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -133,11 +133,6 @@ html_theme_options = {
             'icon': 'fa fa-book fa-fw',
         },
         {
-            'name': 'Slack Community',
-            'url': 'http://slack.pyvista.org',
-            'icon': 'fab fa-slack',
-        },
-        {
             'name': 'Contributing',
             'url': 'https://github.com/pyvista/pyvista/blob/main/CONTRIBUTING.rst',
             'icon': 'fa fa-gavel fa-fw',

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -39,7 +39,7 @@ Questions
 ~~~~~~~~~
 
 If you have any questions about PyVista, feel free to post your questions in
-|discuss| or |slack|.
+|discuss|.
 
 
 Tutorial Overview
@@ -70,9 +70,6 @@ Tutorial Overview
 
 .. |discuss| image:: https://img.shields.io/badge/GitHub-Discussions-green?logo=github
    :target: https://github.com/pyvista/pyvista/discussions
-
-.. |slack| image:: https://img.shields.io/badge/Slack-pyvista-green.svg?logo=slack
-   :target: http://slack.pyvista.org
 
 .. _Alex Kaszynski: https://github.com/akaszynski
 .. _Bane Sullivan: https://banesullivan.com


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Remove the Slack link considering the situation where GitHub Discussion was active when a participant asked a tutorial question.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None