### PR TITLE
Allow deploying preview of the forked repository using  label

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,8 @@
 name: Build Documentation
 on:
   pull_request:
+  pull_request_target:
+    types: [labeled]
   push:
     branches:
       - main


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Allow deploying preview of the forked repository using the label.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Currently, deploy preview from forked repositories is disabled. This is for security reasons. However, it is inconvenient that a preview is not available for review, so this PR lets the maintainer preview documents by labeling them. Security is ensured because only the maintainer can apply labels.
