### PR TITLE
Add  `workflow_dispatch` to deploy document manually

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add  `workflow_dispatch` to deploy the document manually from the Actions tab.
This is useful when you want to deploy a document in a pull request from an external repository by hand.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None