### PR TITLE
Update Trame Turorial Main Page: Use Vuetify 3.

### DIFF
--- a/tutorial/09_trame/README.rst
+++ b/tutorial/09_trame/README.rst
@@ -67,7 +67,7 @@ contains all of the boilerplate code needed to get started.
       .. code:: python
 
         from trame.app import get_server
-        from trame.ui.vuetify import SinglePageLayout
+        from trame.ui.vuetify3 import SinglePageLayout
 
         import pyvista as pv
         from pyvista.trame.ui import plotter_ui


### PR DESCRIPTION
### Overview

This PR follows https://github.com/pyvista/pyvista-tutorial/pull/213 which updates vuetify version in pyvista and trame tutorial.
Currently, the tutorial [main page](https://tutorial.pyvista.org/tutorial/09_trame/index.html) does not import vuetify3. 
It fixes a missing update of the trame tutorial related to vuetify3.


### Details

See https://github.com/pyvista/pyvista/issues/5430#issuecomment-2035012289 and https://github.com/pyvista/pyvista-tutorial/pull/213
