### PR TITLE
Fix deprecated method overwrite in doc

### DIFF
--- a/tutorial/08_widgets/d_multi-slider-widget.py
+++ b/tutorial/08_widgets/d_multi-slider-widget.py
@@ -31,7 +31,7 @@ class MyCustomRoutine:
     def update(self):
         # This is where you call your simulation
         result = pv.Sphere(**self.kwargs)
-        self.output.overwrite(result)
+        self.output.copy_from(result)
         return
 
 


### PR DESCRIPTION
### Overview
<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

The overwrite method has been deprecated according to this post: https://github.com/pyvista/pyvista/issues/3142.

### Details

Replace it with `copy_from`. Confirmed working locally.
