### PR TITLE
Add `pv.start_xvfb()` in first cell in not `vtk-egl` environment

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -245,8 +245,8 @@ sphinx_gallery_conf = {
     '\n'
     '    set_plot_theme("document")\n',
     '\n'
-'import pyvista as pv\n'
-'pv.start_xvfb()\n'
+    'import pyvista as pv\n'
+    'pv.start_xvfb()\n'
     'binder': {
         'org': "pyvista",
         'repo': "pyvista-tutorial",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -245,10 +245,8 @@ sphinx_gallery_conf = {
     '\n'
     '    set_plot_theme("document")\n',
     '\n'
-    'import vtkmodules\n'
-    'if not hasattr(vtkmodules "vtkEGLRenderWindow")\n'
-    '    # vtk is not egl.\n'
-    '    pv.start_xvfb()\n'
+'import pyvista as pv\n'
+'pv.start_xvfb()\n'
     'binder': {
         'org': "pyvista",
         'repo': "pyvista-tutorial",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -244,6 +244,11 @@ sphinx_gallery_conf = {
     '    from pyvista import set_plot_theme\n'
     '\n'
     '    set_plot_theme("document")\n',
+    '\n'
+    'import vtkmodules\n'
+    'if not hasattr(vtkmodules "vtkEGLRenderWindow")\n'
+    '    # vtk is not egl.\n'
+    '    pv.start_xvfb()\n'
     'binder': {
         'org': "pyvista",
         'repo': "pyvista-tutorial",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -243,10 +243,10 @@ sphinx_gallery_conf = {
     '    %matplotlib inline\n'
     '    from pyvista import set_plot_theme\n'
     '\n'
-    '    set_plot_theme("document")\n',
+    '    set_plot_theme("document")\n'
     '\n'
     'import pyvista as pv\n'
-    'pv.start_xvfb()\n'
+    'pv.start_xvfb()\n',
     'binder': {
         'org': "pyvista",
         'repo': "pyvista-tutorial",


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `pv.start_xvfb()` in first cell in not `vtk-egl` environment.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None