### PR TITLE
Remove first notebook cell

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -225,25 +225,6 @@ sphinx_gallery_conf = {
     # Modules for which function level galleries are created.  In
     'doc_module': 'pyvista',
     'image_scrapers': (DynamicScraper(), 'matplotlib'),
-    'first_notebook_cell': 'import subprocess\n'
-    'import sys\n'
-    '\n'
-    'if "google.colab" in sys.modules:\n'
-    '    subprocess.run("apt-get update", shell=True, check=True)\n'
-    '    subprocess.run("apt-get install -qq xvfb libgl1-mesa-glx", shell=True, check=True)\n'
-    '    subprocess.run("pip install pyvista[all] -qq", shell=True, check=True)\n'
-    '\n'
-    '    import pyvista as pv\n'
-    '\n'
-    '    # Seems that only static plotting is supported by colab at the moment\n'
-    '    pv.global_theme.jupyter_backend = "static"\n'
-    '    pv.global_theme.notebook = True\n'
-    '    pv.start_xvfb()\n'
-    'else:\n'
-    '    %matplotlib inline\n'
-    '    from pyvista import set_plot_theme\n'
-    '\n'
-    '    set_plot_theme("document")\n',
     'binder': {
         'org': "pyvista",
         'repo': "pyvista-tutorial",


### PR DESCRIPTION
The first notebook cell shouldn't really be necessary anymore.

- The "document" theme is now PyVista's default
- Colab is supported with the html backend now (ref https://github.com/pyvista/pyvista/issues/5488)
- Colab isn't the recommend platform, we encourage running locally or using mybinder (link in README)