### PR TITLE
Fix mirror of the `prettier` npm package for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
     hooks:
       - id: check-github-workflows
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Use https://github.com/rbubley/mirrors-prettier instead of https://github.com/pre-commit/mirrors-prettier in .pre-commit-config.yaml.
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://learn.scientific-python.org/development/guides/style#PC180