### PR TITLE
Remove isort and pydocstyle setting from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,6 @@
 name = "pyvista-tutorial"
 requires-python = '>=3.9'
 
-[tool.isort]
-profile = "black"
-line_length = 100
-# Sort by name, don't cluster "from" vs "import"
-force_sort_within_sections = true
-# Combines "as" imports on the same line
-combine_as_imports = true
-skip_glob = "pyvista/**/__init__.py,pyvista/__init__.py"
-
-[tool.pydocstyle]
-match = '(?!coverage).*.py'
-
 [tool.ruff]
 exclude = [
     '.git',


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Remove isort and pydocstyle setting from `pyproject.toml`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow up of #346