### PR TITLE
Update block splitter syntax to # %%

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ imageio>=2.5.0
 imageio-ffmpeg
 ipywidgets<9.0.0
 jupyterlab<5.0.0
+jupytext
 matplotlib
 pyvista[all]
 sphinx

--- a/tutorial/00_intro/a_basic.py
+++ b/tutorial/00_intro/a_basic.py
@@ -9,7 +9,7 @@ This is the "Hello, world!" of PyVista.
 
 import pyvista as pv
 
-###############################################################################
+# %%
 # This runs through several of the available geometric objects available in
 # VTK which PyVista provides simple convenience methods for generating.
 #
@@ -25,7 +25,7 @@ cone = pv.Cone()
 poly = pv.Polygon()
 disc = pv.Disc()
 
-###############################################################################
+# %%
 # Now let's plot them all in one window
 
 p = pv.Plotter(shape=(3, 3))
@@ -55,7 +55,7 @@ p.show()
 # Export this plotter as an interactive scene to a HTML file.
 # p.export_html("a_basic.html")
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/00_jupyter/jupyter.py
+++ b/tutorial/00_jupyter/jupyter.py
@@ -10,14 +10,14 @@ import pyvista as pv
 # Set/enable the backed
 pv.set_jupyter_backend("trame")
 
-###############################################################################
+# %%
 
 pl = pv.Plotter()
 pl.add_mesh(pv.ParametricKlein())
 pl.show()
 
 
-###############################################################################
+# %%
 # Client-side rendering only (in browser)
 
 pl = pv.Plotter()
@@ -25,14 +25,14 @@ pl.add_mesh(pv.ParametricRandomHills().elevation())
 pl.show(jupyter_backend="client")
 
 
-###############################################################################
+# %%
 # Server-side rendering only
 
 pl = pv.Plotter()
 pl.add_volume(pv.Wavelet())
 pl.show(jupyter_backend="server")
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/01_basic/a_lesson_basic.py
+++ b/tutorial/01_basic/a_lesson_basic.py
@@ -17,7 +17,7 @@ from pyvista import examples
 # pv.set_plot_theme('document')
 
 
-###############################################################################
+# %%
 # Using Existing Data
 # ~~~~~~~~~~~~~~~~~~~
 # There are two main ways of getting data into PyVista: creating it yourself from
@@ -35,13 +35,13 @@ from pyvista import examples
 dataset = examples.download_saddle_surface()
 dataset
 
-###############################################################################
+# %%
 # Note how this is a :class:`pyvista.PolyData`, which is effectively a surface
 # dataset containing points, lines, and/or faces. We can immediately plot this with:
 
 dataset.plot()
 
-###############################################################################
+# %%
 # This is a fairly basic plot. You can change how its plotted by adding
 # parameters as ``show_edges=True`` or changing the color by setting ``color`` to
 # a different value. All of this is described in PyVista's API documentation in
@@ -51,7 +51,7 @@ dataset.plot()
 dataset = examples.download_frog()
 dataset
 
-###############################################################################
+# %%
 # This is a :class:`pyvista.ImageData`, which is a dataset containing a uniform
 # set of points with consistent spacing. When we plot this dataset, we have the
 # option of enabling volumetric plotting, which plots individual cells based on
@@ -60,7 +60,7 @@ dataset
 dataset.plot(volume=True)
 
 
-###############################################################################
+# %%
 # Read from a file
 # ~~~~~~~~~~~~~~~~
 # You can read datasets directly from a file if you have access to it on your
@@ -75,13 +75,13 @@ dataset.plot(volume=True)
 dataset = pv.read("ironProt.vtk")
 dataset
 
-###############################################################################
+# %%
 # This is again a :class:`pyvista.ImageData` and we can plot it volumetrically
 # with:
 
 dataset.plot(volume=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/01_basic/exercises/a_load_examples_exercise.py
+++ b/tutorial/01_basic/exercises/a_load_examples_exercise.py
@@ -16,13 +16,13 @@ PyVista without having to manually download and load them.
 
 """
 
-###############################################################################
+# %%
 # Import PyVista and the examples module
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Surface DataSet - Download
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Download a surface dataset of pine roots. Note how the dataset is
@@ -31,14 +31,14 @@ dataset = examples.download_pine_roots()
 dataset
 
 
-###############################################################################
+# %%
 # Surface DataSet - Plot
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Plot the pine roots using PyVista's default plotting settings.
 dataset.plot()
 
 
-###############################################################################
+# %%
 # Volume DataSet - Download
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Download the bolt dataset. This is an excellent dataset to visualize using
@@ -48,7 +48,7 @@ dataset = examples.download_bolt_nut()
 dataset
 
 
-###############################################################################
+# %%
 # Volume DataSet - Plot
 # ~~~~~~~~~~~~~~~~~~~~~
 # Here, we plot the dataset using a custom view direction using
@@ -65,7 +65,7 @@ pl.camera_position = [(194.6, -141.8, 182.0), (34.5, 61.0, 32.5), (-0.229, 0.45,
 pl.show()
 
 
-###############################################################################
+# %%
 # Exercise #1 - Use PyVista Examples
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Visualize one of PyVista's built in examples.
@@ -75,7 +75,7 @@ pl.show()
 # examples you can download.
 
 
-###############################################################################
+# %%
 # Exercise #2 - Download and View a File
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Experiment on your own by downloading a dataset and reading it in with
@@ -86,7 +86,7 @@ pl.show()
 # - `Sample STL files <https://www.amtekcompany.com/teaching-resources/stl-files/>`_
 # - `Thingiverse <https://www.thingiverse.com/>`_
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/01_basic/solutions/a_load_examples_solution.py
+++ b/tutorial/01_basic/solutions/a_load_examples_solution.py
@@ -19,13 +19,13 @@ PyVista without having to manually download and load them.
 
 """
 
-###############################################################################
+# %%
 # Import PyVista and the examples module
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Surface DataSet - Download
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Download a surface dataset of pine roots. Note how the dataset is
@@ -34,14 +34,14 @@ dataset = examples.download_pine_roots()
 dataset
 
 
-###############################################################################
+# %%
 # Surface DataSet - Plot
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Plot the pine roots using PyVista's default plotting settings.
 dataset.plot()
 
 
-###############################################################################
+# %%
 # Volume DataSet - Download
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Download the bolt dataset. This is an excellent dataset to visualize using
@@ -51,7 +51,7 @@ dataset = examples.download_bolt_nut()
 dataset
 
 
-###############################################################################
+# %%
 # Volume DataSet - Plot
 # ~~~~~~~~~~~~~~~~~~~~~
 # Here, we plot the dataset using a custom view direction using
@@ -68,7 +68,7 @@ pl.camera_position = [(194.6, -141.8, 182.0), (34.5, 61.0, 32.5), (-0.229, 0.45,
 pl.show()
 
 
-###############################################################################
+# %%
 # Exercise #1 - Use PyVista Examples
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Visualize one of PyVista's built in examples.
@@ -87,7 +87,7 @@ bodies.plot(
 )
 
 
-###############################################################################
+# %%
 # Exercise #2 - Download and View a File
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Experiment on your own by downloading a dataset and reading it in with
@@ -105,7 +105,7 @@ bodies.plot(
 mesh = pv.read("P_shelf_pin.stl")
 mesh.plot()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/a_lesson_mesh.py
+++ b/tutorial/02_mesh/a_lesson_mesh.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # What is a Point?
 # ^^^^^^^^^^^^^^^^
 #
@@ -22,15 +22,15 @@ from pyvista import examples
 points = np.random.rand(100, 3)
 points[:5, :]  # output first 5 rows
 
-###############################################################################
+# %%
 # Pass numpy array of points (n by 3) to PolyData
 mesh = pv.PolyData(points)
 mesh
 
-###############################################################################
+# %%
 mesh.plot(point_size=10, style="points")
 
-###############################################################################
+# %%
 # But it's important to note that most meshes have some sort of connectivity
 # between points such as this gridded mesh:
 
@@ -43,7 +43,7 @@ pl.add_points(mesh.points, color="red", point_size=20, render_points_as_spheres=
 pl.camera_position = cpos
 pl.show()
 
-###############################################################################
+# %%
 mesh = examples.download_bunny_coarse()
 
 pl = pv.Plotter()
@@ -52,7 +52,7 @@ pl.add_points(mesh.points, color="red", point_size=10)
 pl.camera_position = [(0.02, 0.30, 0.73), (0.02, 0.03, -0.022), (-0.03, 0.94, -0.34)]
 pl.show()
 
-###############################################################################
+# %%
 # What is a Cell?
 # ^^^^^^^^^^^^^^^
 #
@@ -74,12 +74,12 @@ pl.add_mesh(single_cell, color="pink", edge_color="blue", line_width=5, show_edg
 pl.camera_position = [(6.20, 3.00, 7.50), (0.16, 0.13, 2.65), (-0.28, 0.94, -0.21)]
 pl.show()
 
-###############################################################################
+# %%
 # Cells aren't limited to voxels, they could be a triangle between three
 # points, a line between two points, or even a single point could be its own
 # cell (but that's a special case).
 
-###############################################################################
+# %%
 # What are attributes?
 # ^^^^^^^^^^^^^^^^^^^^
 #
@@ -90,7 +90,7 @@ pl.show()
 # dictionary-like attribute attached to any PyVista mesh accessible as one
 # of the following:
 
-###############################################################################
+# %%
 # Point Data
 # ~~~~~~~~~~
 # Point data refers to arrays of values (scalars, vectors, etc.) that live on
@@ -101,7 +101,7 @@ pl.show()
 mesh.point_data["my point values"] = np.arange(mesh.n_points)
 mesh.plot(scalars="my point values", cpos=cpos, show_edges=True)
 
-###############################################################################
+# %%
 # Cell Data
 # ~~~~~~~~~~
 # Cell data refers to arrays of values (scalars, vectors, etc.) that live
@@ -111,7 +111,7 @@ mesh.plot(scalars="my point values", cpos=cpos, show_edges=True)
 mesh.cell_data["my cell values"] = np.arange(mesh.n_cells)
 mesh.plot(scalars="my cell values", cpos=cpos, show_edges=True)
 
-###############################################################################
+# %%
 # Here's a comparison of point data versus cell data and how point data is
 # interpolated across cells when mapping colors. This is unlike cell data
 # which has a single value across the cell's domain:
@@ -128,7 +128,7 @@ pl.add_mesh(uni, scalars="Spatial Cell Data", show_edges=True)
 pl.link_views()
 pl.show()
 
-###############################################################################
+# %%
 # Field Data
 # ~~~~~~~~~~
 # Field data is not directly associated with either the points or cells but
@@ -137,7 +137,7 @@ mesh = pv.Cube()
 mesh.field_data["metadata"] = ["Foo", "bar"]
 mesh.field_data
 
-###############################################################################
+# %%
 # Assigning Scalars to a Mesh
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -158,7 +158,7 @@ pl.subplot(0, 1)
 pl.add_mesh(other_cube, cmap="coolwarm")
 pl.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/exercises/b_create-point-cloud.py
+++ b/tutorial/02_mesh/exercises/b_create-point-cloud.py
@@ -13,7 +13,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Point clouds are generally constructed using :class:`pyvista.PolyData` and
 # can easily have scalar or vector data arrays associated with the individual
 # points. In this example, we'll start by working backwards using a point cloud
@@ -35,27 +35,27 @@ points = generate_points()
 # Columns are (X, Y, Z)
 points[0:5, :]
 
-###############################################################################
+# %%
 # Now that you have a NumPy array of points/vertices either from our sample
 # data or your own project, create a PyVista mesh using those points.
 
 # insert your code here
 point_cloud = ...
 
-###############################################################################
+# %%
 # Now, perform a sanity check to show that the points have been loaded
 # correctly.
 
 np.allclose(points, point_cloud.points)
 
-###############################################################################
+# %%
 # Now that we have a PyVista mesh, we can plot it. Note that we add an option
 # to use eye dome lighting - this is a shading technique to improve depth
 # perception with point clouds (learn more about `EDL
 # <https://docs.pyvista.org/examples/02-plot/edl.html>`_).
 point_cloud.plot(eye_dome_lighting=True)
 
-###############################################################################
+# %%
 # Now what if you have data attributes (scalar or vector arrays) that you'd
 # like to associate with every point of your mesh? You can easily add NumPy
 # data arrays that have a length equal to the number of points in the mesh
@@ -71,18 +71,18 @@ point_cloud.plot(eye_dome_lighting=True)
 
 data = ...  # your code here
 
-###############################################################################
+# %%
 # Add that data to the mesh with the name "elevation".
 
 # your code here
 
-###############################################################################
+# %%
 # And now we can plot the point cloud with that elevation data. PyVista is
 # smart enough to plot the scalar array you added by default. This time, let's
 # render every point as its own sphere using ``render_points_as_spheres``.
 point_cloud.plot(render_points_as_spheres=True)
 
-###############################################################################
+# %%
 # That data is kind of boring, right? You can also add data arrays with more
 # than one scalar value - perhaps a vector with three elements? Let's make a
 # little function that will compute vectors for every point in the point cloud
@@ -108,11 +108,11 @@ vectors = compute_vectors(point_cloud)
 vectors[0:5, :]
 
 
-###############################################################################
+# %%
 # Add the vector array as point data to the new mesh:
 
 
-###############################################################################
+# %%
 # Now we can make arrows using those vectors using the glyph filter (see the
 # `Glyph Example <https://docs.pyvista.org/examples/01-filter/glyphs.html>`_
 # for more details).
@@ -132,7 +132,7 @@ plotter.add_mesh(arrows, color="lightblue")
 plotter.show_grid()
 plotter.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/exercises/c_create-uniform-grid.py
+++ b/tutorial/02_mesh/exercises/c_create-uniform-grid.py
@@ -11,44 +11,44 @@ Create a simple uniform grid from a 3D NumPy array of values.
 import numpy as np
 import pyvista as pv
 
-###############################################################################
+# %%
 # Take a 3D NumPy array of data values that holds some spatial data where each
 # axis corresponds to the XYZ cartesian axes. This example will create a
 # :class:`pyvista.ImageData` that will hold the spatial reference for
 # a 3D grid by which a 3D NumPy array of values can be plotted against.
 
-###############################################################################
+# %%
 # Create the 3D NumPy array of spatially referenced data. This is spatially
 # referenced such that the grid is ``(20, 5, 10)``, ``(nx, ny, nz)``.
 values = np.linspace(0, 10, 1000).reshape((20, 5, 10))
 values.shape
 
-###############################################################################
+# %%
 # Create the ImageData
 grid = pv.ImageData()
 
-###############################################################################
+# %%
 # Set the grid dimensions to ``shape + 1`` because we want to inject our values
 # on the CELL data.
 grid.dimensions = np.array(values.shape) + 1
 
-###############################################################################
+# %%
 # Edit the spatial reference.
 grid.origin = (100, 33, 55.6)  # The bottom left corner of the data set
 grid.spacing = (1, 5, 2)  # These are the cell sizes along each axis
 
-###############################################################################
+# %%
 # Assign the data to the cell data. Be sure to flatten the data for
 # ``ImageData`` objects using Fortran ordering.
 grid.cell_data["values"] = values.flatten(order="F")
 grid
 
-###############################################################################
+# %%
 # Now plot the grid!
 grid.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Don't like cell data? You could also add the NumPy array to the point data of
 # a :class:`pyvista.ImageData`. Take note of the subtle difference when
 # setting the grid dimensions upon initialization.
@@ -57,7 +57,7 @@ grid.plot(show_edges=True)
 values = np.linspace(0, 10, 1000).reshape((20, 5, 10))
 values.shape
 
-###############################################################################
+# %%
 # Create the PyVista object and set the same attributes as earlier.
 grid = pv.ImageData()
 
@@ -69,29 +69,29 @@ grid.dimensions = values.shape
 grid.origin = (100, 33, 55.6)  # The bottom left corner of the data set
 grid.spacing = (1, 5, 2)  # These are the cell sizes along each axis
 
-###############################################################################
+# %%
 # Add the data values to the cell data
 grid.point_data["values"] = values.flatten(order="F")  # Flatten the array!
 grid
 
-###############################################################################
+# %%
 # Now plot the grid!
 grid.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Exercise
 # ^^^^^^^^
 # Now create your own :class:`pyvista.ImageData` from a 3D NumPy array!
 help(pv.ImageData)
 
-###############################################################################
+# %%
 # Generate example 3D data using :func:`numpy.random.random`. Feel free to use
 # your own 3D numpy array here.
 arr = np.random.random((100, 100, 100))
 arr.shape
 
-###############################################################################
+# %%
 # Create the :class:`pyvista.ImageData`.
 #
 # .. note::
@@ -101,12 +101,12 @@ arr.shape
 vol = pv.ImageData()
 # Set attributes and data
 
-###############################################################################
+# %%
 # Plot the ImageData
 vol.plot()
 
 
-###############################################################################
+# %%
 # Example
 # ^^^^^^^
 # PyVista has several examples that use ``ImageData``.
@@ -123,11 +123,11 @@ p = pv.Plotter()
 p.add_volume(vol, cmap="bone", opacity="sigmoid")
 p.show()
 
-###############################################################################
+# %%
 vol = pv.Wavelet()
 vol.plot(volume=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/exercises/d_create-tri-surface.py
+++ b/tutorial/02_mesh/exercises/d_create-tri-surface.py
@@ -13,7 +13,7 @@ Create a surface from a set of points through a Delaunay triangulation.
 import numpy as np
 import pyvista as pv
 
-###############################################################################
+# %%
 # Simple Triangulations
 # +++++++++++++++++++++
 #
@@ -31,7 +31,7 @@ zz = A * np.exp(-0.5 * ((xx / b) ** 2.0 + (yy / b) ** 2.0))
 points = np.c_[xx.reshape(-1), yy.reshape(-1), zz.reshape(-1)]
 points[0:5, :]
 
-###############################################################################
+# %%
 # Now use those points to create a point cloud PyVista data object. This will
 # be encompassed in a :class:`pyvista.PolyData` object.
 
@@ -39,13 +39,13 @@ points[0:5, :]
 cloud = ...
 cloud.plot(point_size=15)
 
-###############################################################################
+# %%
 # Now that we have a PyVista data structure of the points, we can perform a
 # triangulation to turn those boring discrete points into a connected surface.
 # See :func:`pyvista.UnstructuredGridFilters.delaunay_2d`.
 help(cloud.delaunay_2d)
 
-###############################################################################
+# %%
 # Apply the ``delaunay_2d`` filter.
 
 surf = ...
@@ -54,7 +54,7 @@ surf = ...
 surf.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Clean Edges & Triangulations
 # ++++++++++++++++++++++++++++
 
@@ -70,21 +70,21 @@ points[:, 1] += np.random.rand(len(points)) * 0.3
 cloud = pv.PolyData(points)
 cloud
 
-###############################################################################
+# %%
 cloud.plot(cpos="xy")
 
-###############################################################################
+# %%
 # Run the triangulation on these points
 surf = cloud.delaunay_2d()
 surf.plot(cpos="xy", show_edges=True)
 
-###############################################################################
+# %%
 # Note that some of the outer edges are unconstrained and the triangulation
 # added unwanted triangles. We can mitigate that with the ``alpha`` parameter.
 surf = cloud.delaunay_2d(alpha=...)
 surf.plot(cpos="xy", show_edges=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/exercises/e_read-file.py
+++ b/tutorial/02_mesh/exercises/e_read-file.py
@@ -8,7 +8,7 @@ Read a dataset from a known file type.
 
 """
 
-###############################################################################
+# %%
 # We try to make loading a mesh as easy as possible - if your data is in one
 # of the many supported file formats, simply use :func:`pyvista.read` to
 # load your spatially referenced dataset into a PyVista mesh object.
@@ -20,16 +20,16 @@ Read a dataset from a known file type.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 help(pv.read)
 
-###############################################################################
+# %%
 # PyVista supports a wide variety of file formats. The supported file
 # extensions are listed in an internal function:
 help(pv.core.utilities.reader.get_reader)
 
 
-###############################################################################
+# %%
 # The following code block uses a built-in example
 # file, displays an airplane mesh and returns the camera's position:
 
@@ -37,7 +37,7 @@ help(pv.core.utilities.reader.get_reader)
 filename = examples.planefile
 filename
 
-###############################################################################
+# %%
 # Note the above filename, it's a ``.ply`` file - one of the many supported
 # formats in PyVista.
 #
@@ -47,50 +47,50 @@ mesh = ...
 cpos = mesh.plot()
 
 
-###############################################################################
+# %%
 # The points from the mesh are directly accessible as a NumPy array:
 
 mesh.points
 
-###############################################################################
+# %%
 # The faces from the mesh are also directly accessible as a NumPy array:
 
 mesh.faces.reshape(-1, 4)[:, 1:]  # triangular faces
 
 
-###############################################################################
+# %%
 # Loading other files types is just as easy! Simply pass your file path to the
 # :func:`pyvista.read` function and that's it!
 #
 # Here are a few other examples - simply replace ``examples.download_*`` in the
 # examples below with ``pyvista.read('path/to/you/file.ext')``
 
-###############################################################################
+# %%
 # Example STL file:
 mesh = examples.download_cad_model()
 cpos = [(107.0, 68.5, 204.0), (128.0, 86.5, 223.5), (0.45, 0.36, -0.8)]
 mesh.plot(cpos=cpos)
 
-###############################################################################
+# %%
 # Example OBJ file
 mesh = examples.download_doorman()
 mesh.plot(cpos="xy")
 
 
-###############################################################################
+# %%
 # Example BYU file
 mesh = examples.download_teapot()
 mesh.plot(cpos=[-1, 2, -5], show_edges=True)
 
 
-###############################################################################
+# %%
 # Example VTK file
 mesh = examples.download_bunny_coarse()
 cpos = [(0.2, 0.3, 0.9), (0, 0, 0), (0, 1, 0)]
 mesh.plot(cpos=cpos, show_edges=True, color=True)
 
 
-###############################################################################
+# %%
 # Exercise
 # ^^^^^^^^
 # Read a file yourself with :func:`pyvista.read`. If you have a supported file
@@ -100,7 +100,7 @@ mesh.plot(cpos=cpos, show_edges=True, color=True)
 # (your code here)
 # mesh = pv.read('path/to/file.vtk)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/solutions/b_create-point-cloud.py
+++ b/tutorial/02_mesh/solutions/b_create-point-cloud.py
@@ -13,7 +13,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Point clouds are generally constructed using :class:`pyvista.PolyData` and
 # can easily have scalar or vector data arrays associated with the individual
 # points. In this example, we'll start by working backwards using a point cloud
@@ -35,27 +35,27 @@ points = generate_points()
 # Columns are (X, Y, Z)
 points[0:5, :]
 
-###############################################################################
+# %%
 # Now that you have a NumPy array of points/vertices either from our sample
 # data or your own project, create a PyVista mesh using those points.
 
 point_cloud = pv.PolyData(points)
 point_cloud
 
-###############################################################################
+# %%
 # Now, perform a sanity check to show that the points have been loaded
 # correctly.
 
 np.allclose(points, point_cloud.points)
 
-###############################################################################
+# %%
 # Now that we have a PyVista mesh, we can plot it. Note that we add an option
 # to use eye dome lighting - this is a shading technique to improve depth
 # perception with point clouds (learn more about `EDL
 # <https://docs.pyvista.org/examples/02-plot/edl.html>`_).
 point_cloud.plot(eye_dome_lighting=True)
 
-###############################################################################
+# %%
 # Now what if you have data attributes (scalar or vector arrays) that you'd
 # like to associate with every point of your mesh? You can easily add NumPy
 # data arrays that have a length equal to the number of points in the mesh
@@ -72,18 +72,18 @@ point_cloud.plot(eye_dome_lighting=True)
 # Make data array using z-component of points array
 data = points[:, -1]
 
-###############################################################################
+# %%
 # Add that data to the mesh with the name "elevation".
 
 point_cloud["elevation"] = data
 
-###############################################################################
+# %%
 # And now we can plot the point cloud with that elevation data. PyVista is
 # smart enough to plot the scalar array you added by default. This time, let's
 # render every point as its own sphere using ``render_points_as_spheres``.
 point_cloud.plot(render_points_as_spheres=True)
 
-###############################################################################
+# %%
 # That data is kind of boring, right? You can also add data arrays with more
 # than one scalar value - perhaps a vector with three elements? Let's make a
 # little function that will compute vectors for every point in the point cloud
@@ -109,12 +109,12 @@ vectors = compute_vectors(point_cloud)
 vectors[0:5, :]
 
 
-###############################################################################
+# %%
 # Add the vector array as point data to the new mesh:
 
 point_cloud["vectors"] = vectors
 
-###############################################################################
+# %%
 # Now we can make arrows using those vectors using the glyph filter (see the
 # `Glyph Example <https://docs.pyvista.org/examples/01-filter/glyphs.html>`_
 # for more details).
@@ -134,7 +134,7 @@ plotter.add_mesh(arrows, color="lightblue")
 plotter.show_grid()
 plotter.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/solutions/c_create-uniform-grid.py
+++ b/tutorial/02_mesh/solutions/c_create-uniform-grid.py
@@ -11,44 +11,44 @@ Create a simple uniform grid from a 3D NumPy array of values.
 import numpy as np
 import pyvista as pv
 
-###############################################################################
+# %%
 # Take a 3D NumPy array of data values that holds some spatial data where each
 # axis corresponds to the XYZ cartesian axes. This example will create a
 # :class:`pyvista.ImageData` that will hold the spatial reference for
 # a 3D grid by which a 3D NumPy array of values can be plotted against.
 
-###############################################################################
+# %%
 # Create the 3D NumPy array of spatially referenced data.  This is spatially
 # referenced such that the grid is ``(20, 5, 10)`` ``(nx, ny, nz)``.
 values = np.linspace(0, 10, 1000).reshape((20, 5, 10))
 values.shape
 
-###############################################################################
+# %%
 # Create the ImageData
 grid = pv.ImageData()
 
-###############################################################################
+# %%
 # Set the grid dimensions to ``shape + 1`` because we want to inject our values
 # on the CELL data.
 grid.dimensions = np.array(values.shape) + 1
 
-###############################################################################
+# %%
 # Edit the spatial reference
 grid.origin = (100, 33, 55.6)  # The bottom left corner of the data set
 grid.spacing = (1, 5, 2)  # These are the cell sizes along each axis
 
-###############################################################################
+# %%
 # Assign the data to the cell data. Be sure to flatten the data for
 # ``ImageData`` objects using Fortran ordering.
 grid.cell_data["values"] = values.flatten(order="F")
 grid
 
-###############################################################################
+# %%
 # Now plot the grid!
 grid.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Don't like cell data? You could also add the NumPy array to the point data of
 # a :class:`pyvista.ImageData`. Take note of the subtle difference when
 # setting the grid dimensions upon initialization.
@@ -57,7 +57,7 @@ grid.plot(show_edges=True)
 values = np.linspace(0, 10, 1000).reshape((20, 5, 10))
 values.shape
 
-###############################################################################
+# %%
 # Create the PyVista object and set the same attributes as earlier.
 grid = pv.ImageData()
 
@@ -69,29 +69,29 @@ grid.dimensions = values.shape
 grid.origin = (100, 33, 55.6)  # The bottom left corner of the data set
 grid.spacing = (1, 5, 2)  # These are the cell sizes along each axis
 
-###############################################################################
+# %%
 # Add the data values to the cell data
 grid.point_data["values"] = values.flatten(order="F")  # Flatten the array!
 grid
 
-###############################################################################
+# %%
 # Now plot the grid!
 grid.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Exercise
 # ^^^^^^^^
 # Now create your own :class:`pyvista.ImageData` from a 3D NumPy array!
 help(pv.ImageData)
 
-###############################################################################
+# %%
 # Generate example 3D data using :func:`numpy.random.random`. Feel free to use
 # your own 3D numpy array here.
 arr = np.random.random((100, 100, 100))
 arr.shape
 
-###############################################################################
+# %%
 # Create the :class:`pyvista.ImageData`.
 #
 # .. note::
@@ -102,12 +102,12 @@ vol = pv.ImageData()
 vol.dimensions = arr.shape
 vol["array"] = arr.ravel(order="F")
 
-###############################################################################
+# %%
 # Plot the ImageData
 vol.plot()
 
 
-###############################################################################
+# %%
 # Example
 # ^^^^^^^
 # PyVista has several examples that use ``ImageData``.
@@ -124,11 +124,11 @@ p = pv.Plotter()
 p.add_volume(vol, cmap="bone", opacity="sigmoid")
 p.show()
 
-###############################################################################
+# %%
 vol = pv.Wavelet()
 vol.plot(volume=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/solutions/d_create-tri-surface.py
+++ b/tutorial/02_mesh/solutions/d_create-tri-surface.py
@@ -13,7 +13,7 @@ Create a surface from a set of points through a Delaunay triangulation.
 import numpy as np
 import pyvista as pv
 
-###############################################################################
+# %%
 # Simple Triangulations
 # +++++++++++++++++++++
 #
@@ -31,7 +31,7 @@ zz = A * np.exp(-0.5 * ((xx / b) ** 2.0 + (yy / b) ** 2.0))
 points = np.c_[xx.reshape(-1), yy.reshape(-1), zz.reshape(-1)]
 points[0:5, :]
 
-###############################################################################
+# %%
 # Now use those points to create a point cloud PyVista data object. This will
 # be encompassed in a :class:`pyvista.PolyData` object.
 
@@ -39,13 +39,13 @@ points[0:5, :]
 cloud = pv.PolyData(points)
 cloud.plot(point_size=15)
 
-###############################################################################
+# %%
 # Now that we have a PyVista data structure of the points, we can perform a
 # triangulation to turn those boring discrete points into a connected surface.
 # See :func:`pyvista.UnstructuredGridFilters.delaunay_2d`.
 help(cloud.delaunay_2d)
 
-###############################################################################
+# %%
 # Apply the ``delaunay_2d`` filter.
 
 surf = cloud.delaunay_2d()
@@ -54,7 +54,7 @@ surf = cloud.delaunay_2d()
 surf.plot(show_edges=True)
 
 
-###############################################################################
+# %%
 # Clean Edges & Triangulations
 # ++++++++++++++++++++++++++++
 
@@ -70,21 +70,21 @@ points[:, 1] += np.random.rand(len(points)) * 0.3
 cloud = pv.PolyData(points)
 cloud
 
-###############################################################################
+# %%
 cloud.plot(cpos="xy")
 
-###############################################################################
+# %%
 # Run the triangulation on these points
 surf = cloud.delaunay_2d()
 surf.plot(cpos="xy", show_edges=True)
 
-###############################################################################
+# %%
 # Note that some of the outer edges are unconstrained and the triangulation
 # added unwanted triangles. We can mitigate that with the ``alpha`` parameter.
 surf = cloud.delaunay_2d(alpha=1.0)
 surf.plot(cpos="xy", show_edges=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/02_mesh/solutions/e_read-file.py
+++ b/tutorial/02_mesh/solutions/e_read-file.py
@@ -8,7 +8,7 @@ Read a dataset from a known file type.
 
 """
 
-###############################################################################
+# %%
 # We try to make loading a mesh as easy as possible - if your data is in one
 # of the many supported file formats, simply use :func:`pyvista.read` to
 # load your spatially referenced dataset into a PyVista mesh object.
@@ -20,16 +20,16 @@ Read a dataset from a known file type.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 help(pv.read)
 
-###############################################################################
+# %%
 # PyVista supports a wide variety of file formats. The supported file
 # extensions are listed in an internal function:
 help(pv.core.utilities.reader.get_reader)
 
 
-###############################################################################
+# %%
 # The following code block uses a built-in example
 # file, displays an airplane mesh and returns the camera's position:
 
@@ -37,7 +37,7 @@ help(pv.core.utilities.reader.get_reader)
 filename = examples.planefile
 filename
 
-###############################################################################
+# %%
 # Note the above filename, it's a ``.ply`` file - one of the many supported
 # formats in PyVista.
 #
@@ -47,50 +47,50 @@ mesh = pv.read(filename)
 cpos = mesh.plot()
 
 
-###############################################################################
+# %%
 # The points from the mesh are directly accessible as a NumPy array:
 
 mesh.points
 
-###############################################################################
+# %%
 # The faces from the mesh are also directly accessible as a NumPy array:
 
 mesh.faces.reshape(-1, 4)[:, 1:]  # triangular faces
 
 
-###############################################################################
+# %%
 # Loading other files types is just as easy! Simply pass your file path to the
 # :func:`pyvista.read` function and that's it!
 #
 # Here are a few other examples - simply replace ``examples.download_*`` in the
 # examples below with ``pyvista.read('path/to/you/file.ext')``
 
-###############################################################################
+# %%
 # Example STL file:
 mesh = examples.download_cad_model()
 cpos = [(107.0, 68.5, 204.0), (128.0, 86.5, 223.5), (0.45, 0.36, -0.8)]
 mesh.plot(cpos=cpos)
 
-###############################################################################
+# %%
 # Example OBJ file
 mesh = examples.download_doorman()
 mesh.plot(cpos="xy")
 
 
-###############################################################################
+# %%
 # Example BYU file
 mesh = examples.download_teapot()
 mesh.plot(cpos=[-1, 2, -5], show_edges=True)
 
 
-###############################################################################
+# %%
 # Example VTK file
 mesh = examples.download_bunny_coarse()
 cpos = [(0.2, 0.3, 0.9), (0, 0, 0), (0, 1, 0)]
 mesh.plot(cpos=cpos, show_edges=True, color=True)
 
 
-###############################################################################
+# %%
 # Exercise
 # ^^^^^^^^
 # Read a file yourself with :func:`pyvista.read`. If you have a supported file
@@ -100,7 +100,7 @@ mesh.plot(cpos=cpos, show_edges=True, color=True)
 # (your code here)
 # mesh = pv.read('path/to/file.vtk)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/a_lesson_figures.py
+++ b/tutorial/03_figures/a_lesson_figures.py
@@ -8,7 +8,7 @@ from pyvista import examples
 
 mesh = pv.Wavelet()
 
-###############################################################################
+# %%
 # ``add_mesh``
 # ++++++++++++++
 #
@@ -18,21 +18,21 @@ p = pv.Plotter()
 p.add_mesh(mesh)
 p.show()
 
-###############################################################################
+# %%
 # You can customize how that mesh is displayed through the parameters of the :func:`pyvista.Plotter.add_mesh` method. For example, we can change the colormap via the ``cmap`` argument:
 
 p = pv.Plotter()
 p.add_mesh(mesh, cmap="coolwarm")
 p.show()
 
-###############################################################################
+# %%
 # Or show the edges of the mesh with ``show_edges``:
 
 p = pv.Plotter()
 p.add_mesh(mesh, show_edges=True)
 p.show()
 
-###############################################################################
+# %%
 # Or adjust the opacity to be a scalar value or linear transfer function via the ``opacity`` argument:
 
 mesh = examples.download_st_helens().warp_by_scalar()
@@ -41,7 +41,7 @@ p = pv.Plotter()
 p.add_mesh(mesh, cmap="terrain", opacity="linear")
 p.show()
 
-###############################################################################
+# %%
 # Take a look at all of the options for `add_mesh <https://docs.pyvista.org/api/plotting/_autosummary/pyvista.Plotter.add_mesh.html>`_.
 #
 # The ``add_mesh`` method can be called over and over to add different data to the same ``Plotter`` scene. For example, we can create many different mesh objects and plot them together:
@@ -71,7 +71,7 @@ p.add_floor("-z", lighting=True, color="tan", pad=1.0)
 p.enable_shadows()
 p.show()
 
-###############################################################################
+# %%
 # Subplotting
 # +++++++++++
 #
@@ -86,7 +86,7 @@ p.add_mesh(pv.Cube())
 
 p.show()
 
-###############################################################################
+# %%
 # Below is an example of side-by-side comparisons of the contours and slices of a single dataset.
 #
 # .. tip::
@@ -107,7 +107,7 @@ p.link_views()
 p.view_isometric()
 p.show()
 
-###############################################################################
+# %%
 # Axes and Bounds
 # +++++++++++++++
 #
@@ -121,7 +121,7 @@ p.add_mesh(mesh)
 p.show_axes()
 p.show()
 
-###############################################################################
+# %%
 # And bounds similarly with :func:`pyvista.Plotter.show_bounds`
 #
 # .. tip::
@@ -135,7 +135,7 @@ p.show_axes()
 p.show_bounds()
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/b_shading.py
+++ b/tutorial/03_figures/b_shading.py
@@ -11,7 +11,7 @@ Comparison of default, flat shading vs. smooth shading.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # PyVista supports two types of shading: flat and smooth shading that uses
 # VTK's Phong shading algorithm.
 #
@@ -20,12 +20,12 @@ mesh = examples.load_nut()
 mesh.plot()
 
 
-###############################################################################
+# %%
 # Here's the same sphere with smooth shading.
 mesh.plot(smooth_shading=True)
 
 
-###############################################################################
+# %%
 # Note how smooth shading makes edges that should be sharp look odd,
 # it's because the points of these normals are averaged between two
 # faces that have a sharp angle between them.  You can avoid this by
@@ -37,7 +37,7 @@ mesh.plot(smooth_shading=True)
 mesh.plot(smooth_shading=True, split_sharp_edges=True)
 
 
-###############################################################################
+# %%
 # We can even plot the edges that will be split using
 # :func:`extract_feature_edges <pyvista.PolyDataFilters.extract_feature_edges>`.
 
@@ -54,7 +54,7 @@ pl.add_mesh(edges, color="k", line_width=5)
 pl.show()
 
 
-###############################################################################
+# %%
 # The ``split_sharp_edges`` keyword argument is compatible with
 # physically based rendering as well.
 
@@ -64,7 +64,7 @@ pl = pv.Plotter()
 pl.add_mesh(mesh, color="w", split_sharp_edges=True, pbr=True, metallic=1.0, roughness=0.5)
 pl.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/bonus/d_pbr.py
+++ b/tutorial/03_figures/bonus/d_pbr.py
@@ -30,7 +30,7 @@ mesh.rotate_x(-90.0, inplace=True)  # rotate to orient with the skybox
 cubemap = examples.download_sky_box_cube_map()
 
 
-###############################################################################
+# %%
 # Let's render the mesh with a base color of "linen" to give it a metal looking
 # finish.
 p = pv.Plotter()
@@ -44,7 +44,7 @@ cpos = [(-313.40, 66.09, 1000.61), (0.0, 0.0, 0.0), (0.018, 0.99, -0.06)]
 p.show(cpos=cpos)
 
 
-###############################################################################
+# %%
 # Show the variation of the metallic and roughness parameters.
 #
 # Plot with metallic increasing from left to right and roughness
@@ -63,7 +63,7 @@ p.view_vector((-1, 0, 0), (0, 1, 0))
 p.show()
 
 
-###############################################################################
+# %%
 # Combine custom lighting and physically based rendering.
 
 # download louis model
@@ -91,7 +91,7 @@ plotter.add_light(light)
 plotter.camera_position = [(9.51, 13.92, 15.81), (-2.836, -0.93, 10.2), (-0.22, -0.18, 0.959)]
 cpos = plotter.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/bonus/e_labels.py
+++ b/tutorial/03_figures/bonus/e_labels.py
@@ -10,12 +10,12 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # The :func:`pyvista.Plotter.add_point_labels` method makes it easy to add
 # point labels to a scene.
 help(pv.Plotter.add_point_labels)
 
-###############################################################################
+# %%
 # Label Point Cloud
 # ++++++++++++++++++
 #
@@ -24,26 +24,26 @@ help(pv.Plotter.add_point_labels)
 # Make some random points
 poly = pv.PolyData(np.random.rand(10, 3))
 
-###############################################################################
+# %%
 # Add string labels to the point data - this associates a label with every
 # node:
 
 poly["My Labels"] = [f"Label {i}" for i in range(poly.n_points)]
 poly
 
-###############################################################################
+# %%
 # Now plot the points with labels using :func:`pyvista.Plotter.add_point_labels`
 
 # (your code here, answer below)
 
 
-###############################################################################
+# %%
 plotter = pv.Plotter()
 plotter.add_point_labels(poly, "My Labels", point_size=20, font_size=36)
 plotter.show()
 
 
-###############################################################################
+# %%
 # Label Node Locations
 # ++++++++++++++++++++
 #
@@ -53,7 +53,7 @@ plotter.show()
 grid = pv.UnstructuredGrid(examples.hexbeamfile)
 
 
-###############################################################################
+# %%
 # Create plotting class and add the unstructured grid
 plotter = pv.Plotter()
 plotter.add_mesh(grid, show_edges=True, color="tan")
@@ -68,7 +68,7 @@ plotter.camera_position = [(-1.5, 1.5, 3.0), (0.05, 0.6, 1.2), (0.2, 0.9, -0.25)
 plotter.show()
 
 
-###############################################################################
+# %%
 # Label Scalar Values
 # +++++++++++++++++++
 #
@@ -76,7 +76,7 @@ plotter.show()
 
 mesh = examples.load_uniform().slice()
 
-###############################################################################
+# %%
 p = pv.Plotter()
 
 # Add the mesh:
@@ -89,7 +89,7 @@ p.camera_position = [(7, 4, 5), (4.4, 7.0, 7.2), (0.8, 0.5, 0.25)]
 
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/bonus/g_orbit.py
+++ b/tutorial/03_figures/bonus/g_orbit.py
@@ -27,7 +27,7 @@ from pyvista import examples
 
 mesh = examples.download_st_helens().warp_by_scalar()
 
-###############################################################################
+# %%
 # Orbit around the Mt. St Helens dataset.
 
 p = pv.Plotter()
@@ -40,7 +40,7 @@ p.orbit_on_path(path, write_frames=True)
 p.close()
 
 
-###############################################################################
+# %%
 
 p = pv.Plotter()
 p.add_mesh(mesh, lighting=False)
@@ -53,12 +53,12 @@ p.orbit_on_path(path, write_frames=True, viewup=[0, 0, 1], step=0.05)
 p.close()
 
 
-###############################################################################
+# %%
 
 mesh = examples.download_dragon()
 viewup = [0, 1, 0]
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh)
 p.show(auto_close=False)
@@ -67,7 +67,7 @@ p.open_gif("orbit.gif")
 p.orbit_on_path(path, write_frames=True, viewup=viewup, step=0.05)
 p.close()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/c_geological-map.py
+++ b/tutorial/03_figures/c_geological-map.py
@@ -25,12 +25,12 @@ try:
 except ImportError:
     rasterio = None
 
-###############################################################################
+# %%
 path = examples.download_file("topo_clean.vtk")
 topo = pv.read(path)
 topo
 
-###############################################################################
+# %%
 # Load the GeoTIFF/texture (this could take a minute to download)
 # https://dl.dropbox.com/s/bp9j3fl3wbi0fld/downsampled_Geologic_map_on_air_photo.tif?dl=0
 url = "https://dl.dropbox.com/s/bp9j3fl3wbi0fld/downsampled_Geologic_map_on_air_photo.tif?dl=0"
@@ -40,7 +40,7 @@ filename = os.path.join(tempfile.gettempdir(), "downsampled_Geologic_map_on_air_
 open(filename, "wb").write(response.content)  # noqa: SIM115, PTH123
 
 
-###############################################################################
+# %%
 # In the block below, we can use the ``get_gcps`` function to get the
 # Ground Control Points of the raster, however this depends on GDAL. For this
 # tutorial, we are going to hard code the GCPs to avoid having users install
@@ -72,7 +72,7 @@ def get_gcps(filename):
     return origin, point_u, point_v
 
 
-###############################################################################
+# %%
 
 # Fetch the GCPs
 # origin, point_u, point_v = get_gcps(filename)
@@ -82,12 +82,12 @@ origin = [310967.75148705335, 4238841.045453942, 0.0]
 point_u = [358682.9364281533, 4238841.045453942, 0.0]
 point_v = [310967.75148705335, 4276281.98755258, 0.0]
 
-###############################################################################
+# %%
 
 # Use the GCPs to map the texture coordinates onto the topography surface
 topo.texture_map_to_plane(origin, point_u, point_v, inplace=True)
 
-###############################################################################
+# %%
 # Show GCPs in relation to topo surface with texture coordinates displayed
 p = pv.Plotter()
 p.add_point_labels(
@@ -106,7 +106,7 @@ p.add_mesh(topo)
 p.show(cpos="xy")
 
 
-###############################################################################
+# %%
 # Read the GeoTIFF as a ``Texture`` in PyVista:
 texture = pv.read_texture(filename)
 
@@ -121,7 +121,7 @@ p.camera_position = [
 ]
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/d_gif.py
+++ b/tutorial/03_figures/d_gif.py
@@ -53,7 +53,7 @@ for phase in np.linspace(0, 2 * np.pi, nframe + 1)[:nframe]:
 # Closes and finalizes movie
 plotter.close()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/exercises/a_display_options.py
+++ b/tutorial/03_figures/exercises/a_display_options.py
@@ -14,52 +14,52 @@ p = pv.Plotter()
 p.add_mesh(mesh)
 p.show()
 
-###############################################################################
+# %%
 # Let's take a look at some different options for the ``add_mesh`` method to
 # alter how the above data are displayed.
 help(p.add_mesh)
 
-###############################################################################
+# %%
 # Plot that mesh with the edges of cells displayed
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # Plot that mesh with the colored edges and as a show the surface as a solid
 # color (use a named color!)
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # Display with a points representation style
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # And adjust the points display size
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # Change the color map and the color limits
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # Add some opacity
 p = pv.Plotter()
 p.add_mesh(mesh, ...)
 p.show()
 
-###############################################################################
+# %%
 # There you go! Those are a few of the most commonly used display options!
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/exercises/b_lighting_mesh.py
+++ b/tutorial/03_figures/exercises/b_lighting_mesh.py
@@ -21,15 +21,15 @@ mesh = examples.download_st_helens().warp_by_scalar()
 
 cpos = [(575848.0, 5128459.0, 22289.0), (562835.0, 5114981.5, 2294.5), (-0.5, -0.5, 0.7)]
 
-###############################################################################
+# %%
 # First, let's take a look at the mesh with default lighting conditions
 mesh.plot(cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # What about with no lighting?
 mesh.plot(..., cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Demonstration of the specular property
 #
 # Feel free to adjust the specular value in the ``s`` variable.
@@ -48,20 +48,20 @@ p.link_views()
 p.view_isometric()
 p.show(cpos=cpos)
 
-###############################################################################
+# %%
 # Specular power (feel free to adjust)
 mesh.plot(..., cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Demonstration of all diffuse, specular, and ambient in use together
 # (feel free to adjust)
 mesh.plot(..., cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # For detailed control over lighting conditions in general see the
 # `lighting examples <https://docs.pyvista.org/examples/index.html#lighting>`_
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/exercises/c_edl.py
+++ b/tutorial/03_figures/exercises/c_edl.py
@@ -10,13 +10,13 @@ To learn more, please see `this blog post`_.
 
 """
 
-###############################################################################
+# %%
 
 # sphinx_gallery_thumbnail_number = 1
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Point Cloud
 # +++++++++++
 #
@@ -26,7 +26,7 @@ from pyvista import examples
 point_cloud = examples.download_lidar()
 point_cloud
 
-###############################################################################
+# %%
 # And now plot this point cloud as-is:
 
 # Plot a typical point cloud with no EDL
@@ -35,7 +35,7 @@ p.add_mesh(point_cloud, color="tan", point_size=5)
 p.show()
 
 
-###############################################################################
+# %%
 # We can improve the depth mapping by enabling eye dome lighting on the
 # renderer with :func:`pyvista.Renderer.enable_eye_dome_lighting`.
 #
@@ -47,12 +47,12 @@ p.add_mesh(point_cloud, color="tan", point_size=5)
 p.show()
 
 
-###############################################################################
+# %%
 # The eye dome lighting mode can also handle plotting scalar arrays. Try the
 # above block but by specifying a ``scalars`` array instead of ``color`` in
 # the ``add_mesh`` call.
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/solutions/a_display_options.py
+++ b/tutorial/03_figures/solutions/a_display_options.py
@@ -14,54 +14,54 @@ p = pv.Plotter()
 p.add_mesh(mesh)
 p.show()
 
-###############################################################################
+# %%
 # Let's take a look at some different options for the ``add_mesh`` method to
 # alter how the above data are displayed.
 #
 # See also https://docs.pyvista.org/api/plotting/_autosummary/pyvista.Plotter.add_mesh.html
 help(p.add_mesh)
 
-###############################################################################
+# %%
 # Plot that mesh with the edges of cells displayed
 p = pv.Plotter()
 p.add_mesh(mesh, show_edges=True)
 p.show()
 
-###############################################################################
+# %%
 # Plot that mesh with the colored edges and as a show the surface as a solid
 # color (use a named color!)
 p = pv.Plotter()
 p.add_mesh(mesh, color="magenta", show_edges=True, edge_color="blue")
 p.show()
 
-###############################################################################
+# %%
 # Display with a points representation style
 p = pv.Plotter()
 p.add_mesh(mesh, style="points")
 p.show()
 
-###############################################################################
+# %%
 # And adjust the points display size
 p = pv.Plotter()
 p.add_mesh(mesh, style="points", point_size=10, render_points_as_spheres=True)
 p.show()
 
-###############################################################################
+# %%
 # Change the color map and the color limits
 p = pv.Plotter()
 p.add_mesh(mesh, cmap="terrain", clim=[2, 5])
 p.show()
 
-###############################################################################
+# %%
 # Add some opacity
 p = pv.Plotter()
 p.add_mesh(mesh, cmap="terrain", clim=[2, 5], opacity="linear")
 p.show()
 
-###############################################################################
+# %%
 # There you go! Those are a few of the most commonly used display options!
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/solutions/b_lighting_mesh.py
+++ b/tutorial/03_figures/solutions/b_lighting_mesh.py
@@ -23,15 +23,15 @@ mesh = examples.download_st_helens().warp_by_scalar()
 
 cpos = [(575848.0, 5128459.0, 22289.0), (562835.0, 5114981.5, 2294.5), (-0.5, -0.5, 0.7)]
 
-###############################################################################
+# %%
 # First, lets take a look at the mesh with default lighting conditions
 mesh.plot(cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # What about with no lighting?
 mesh.plot(lighting=False, cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Demonstration of the specular property
 #
 # Feel free to adjust the specular value in the ``s`` variable.
@@ -50,20 +50,20 @@ p.link_views()
 p.view_isometric()
 p.show(cpos=cpos)
 
-###############################################################################
+# %%
 # Specular power (feel free to adjust)
 mesh.plot(specular=0.5, specular_power=15, cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Demonstration of all diffuse, specular, and ambient in use together
 # (feel free to adjust)
 mesh.plot(diffuse=0.5, specular=0.5, ambient=0.5, cpos=cpos, show_scalar_bar=False)
 
-###############################################################################
+# %%
 # For detailed control over lighting conditions in general see the
 # `lighting examples <https://docs.pyvista.org/examples/index.html#lighting>`_
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/03_figures/solutions/c_edl.py
+++ b/tutorial/03_figures/solutions/c_edl.py
@@ -12,13 +12,13 @@ To learn more, please see `this blog post`_.
 
 """
 
-###############################################################################
+# %%
 
 # sphinx_gallery_thumbnail_number = 1
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Point Cloud
 # +++++++++++
 #
@@ -28,7 +28,7 @@ from pyvista import examples
 point_cloud = examples.download_lidar()
 point_cloud
 
-###############################################################################
+# %%
 # And now plot this point cloud as-is:
 
 # Plot a typical point cloud with no EDL
@@ -37,7 +37,7 @@ p.add_mesh(point_cloud, color="tan", point_size=5)
 p.show()
 
 
-###############################################################################
+# %%
 # We can improve the depth mapping by enabling eye dome lighting on the
 # renderer with :func:`pyvista.Renderer.enable_eye_dome_lighting`.
 #
@@ -49,7 +49,7 @@ p.enable_eye_dome_lighting()  # Turn on eye dome lighting here
 p.show()
 
 
-###############################################################################
+# %%
 # The eye dome lighting mode can also handle plotting scalar arrays. Try the
 # above block but by specifying a ``scalars`` array instead of ``color`` in
 # the ``add_mesh`` call.
@@ -59,7 +59,7 @@ p.add_mesh(point_cloud, scalars="Elevation", point_size=5)
 p.enable_eye_dome_lighting()  # Turn on eye dome lighting here
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/a_lesson_filters.py
+++ b/tutorial/04_filters/a_lesson_filters.py
@@ -11,7 +11,7 @@ Using common filters like thresholding and clipping.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # PyVista wrapped data objects have a suite of common filters ready for immediate
 # use directly on the object. These filters include the following
 # (see `filters_ref`_ for a complete list):
@@ -46,7 +46,7 @@ threshed = dataset.threshold([100, 500])
 
 outline = dataset.outline()
 
-###############################################################################
+# %%
 # And now there is a thresholded version of the input dataset in the new
 # ``threshed`` object. To learn more about what keyword arguments are available to
 # alter how filters are executed, print the docstring for any filter attached to
@@ -63,7 +63,7 @@ p.camera_position = [-2, 5, 3]
 p.show()
 
 
-###############################################################################
+# %%
 # What about other filters? Let's collect a few filter results and compare them:
 
 contours = dataset.contour()
@@ -94,7 +94,7 @@ p.camera_position = [-2, 5, 3]
 p.link_views()
 p.show()
 
-###############################################################################
+# %%
 # Filter Pipeline
 # +++++++++++++++
 #
@@ -112,7 +112,7 @@ p.show()
 # Apply a filtering chain
 result = dataset.threshold().elevation().clip(normal="z").slice_orthogonal()
 
-###############################################################################
+# %%
 # And to view this filtered data, simply call the ``plot`` method
 # (``result.plot()``) or create a rendering scene:
 
@@ -122,7 +122,7 @@ p.add_mesh(result, scalars="Elevation")
 p.view_isometric()
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/bonus/f_sampling_functions_3d.py
+++ b/tutorial/04_filters/bonus/f_sampling_functions_3d.py
@@ -11,7 +11,7 @@ we create a voxelized mesh similar to a Minecraft "cave".
 
 import pyvista as pv
 
-###############################################################################
+# %%
 # Generate Perlin Noise over a 3D StructuredGrid
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Feel free to change the values of ``freq`` to change the shape of
@@ -28,7 +28,7 @@ grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(120, 40, 40))
 out = grid.threshold(0.02)
 out
 
-###############################################################################
+# %%
 # color limits without blue
 mn, mx = [out["scalars"].min(), out["scalars"].max()]
 clim = (mn, mx * 1.8)
@@ -42,7 +42,7 @@ out.plot(
     show_edges=False,
 )
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/exercises/b_clipping.py
+++ b/tutorial/04_filters/exercises/b_clipping.py
@@ -9,7 +9,7 @@ Clip/cut any dataset using using planes or boxes.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Clip with Plane
 # +++++++++++++++
 #
@@ -18,15 +18,15 @@ from pyvista import examples
 dataset = examples.download_bunny_coarse()
 dataset
 
-###############################################################################
+# %%
 help(dataset.clip)
 
-###############################################################################
+# %%
 # Perform a clip with a Y axis normal
 clipped = ...
 clipped
 
-###############################################################################
+# %%
 # Plot the result.
 p = pv.Plotter()
 p.add_mesh(dataset, style="wireframe", color="blue", label="Input")
@@ -36,7 +36,7 @@ p.camera_position = [(0.24, 0.32, 0.7), (0.02, 0.03, -0.02), (-0.12, 0.93, -0.34
 p.show()
 
 
-###############################################################################
+# %%
 # Clip with Bounds
 # ++++++++++++++++
 #
@@ -46,17 +46,17 @@ p.show()
 # First, download an example dataset.
 dataset = examples.download_office()
 
-###############################################################################
+# %%
 help(dataset.clip_box)
 
-###############################################################################
+# %%
 # Clip the dataset with a bounding box defined by the values in ``bounds``
 # ``(xmin, xmax, ymin, ymax, zmin, zmax)``
 bounds = [2, 4.5, 2, 4.5, 1, 3]
 clipped = ...
 clipped
 
-###############################################################################
+# %%
 # Plot the original dataset and the clipped one.
 p = pv.Plotter()
 p.add_mesh(dataset, style="wireframe", color="blue", label="Input")
@@ -65,7 +65,7 @@ p.add_legend()
 p.show()
 
 
-###############################################################################
+# %%
 # Clip with Rotated Box
 # +++++++++++++++++++++
 #
@@ -82,7 +82,7 @@ p.add_mesh(roi, opacity=0.75, color="red")
 p.add_mesh(mesh, opacity=0.5)
 p.show()
 
-###############################################################################
+# %%
 # Run the box clipping algorithm with the defined box geometry.
 extracted = ...
 
@@ -96,7 +96,7 @@ p.link_views()
 p.view_isometric()
 p.show()
 
-###############################################################################
+# %%
 # Crinkled Clipping
 # +++++++++++++++++
 # Crinkled clipping is useful if you don't want the clip filter to truly clip
@@ -111,20 +111,20 @@ p.show()
 # Input mesh
 mesh = pv.Wavelet()
 
-###############################################################################
+# %%
 # Define clipping plane
 normal = (1, 1, 1)
 plane = pv.Plane(i_size=30, j_size=30, direction=normal)
 
-###############################################################################
+# %%
 # Perform a standard clip
 clipped = mesh.clip(normal=normal)
 
-###############################################################################
+# %%
 # Perform a crinkled clip to compare
 crinkled = mesh.clip(..., normal=normal)
 
-###############################################################################
+# %%
 # Plot comparison
 p = pv.Plotter(shape=(1, 2))
 p.add_mesh(clipped, show_edges=True)
@@ -135,7 +135,7 @@ p.add_mesh(plane.extract_feature_edges(), color="r")
 p.link_views()
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/exercises/c_compute-normals.py
+++ b/tutorial/04_filters/exercises/c_compute-normals.py
@@ -14,7 +14,7 @@ from pyvista import examples
 mesh = examples.download_topo_global()
 mesh.plot(cmap="gist_earth", show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Now we have a surface dataset of the globe loaded - unfortunately, the
 # dataset shows the globe with a uniform radius which hides topographic relief.
 # Using :func:`pyvista.PolyData.compute_normals`, we can compute the normal
@@ -24,16 +24,16 @@ mesh.plot(cmap="gist_earth", show_scalar_bar=False)
 
 # Compute the normals in-place and use them to warp the globe
 
-###############################################################################
+# %%
 # Now use those normals to warp the surface
 warp = mesh.warp_by_scalar(factor=0.5e-5)
 
-###############################################################################
+# %%
 # And let's see it!
 warp.plot(cmap="gist_earth", show_scalar_bar=False)
 
 
-###############################################################################
+# %%
 # We could also use face or cell normals to extract all the faces of a mesh
 # facing a general direction. In the following snippet, we take a mesh, compute
 # the normals along its cell faces, and extract the faces that face upward.
@@ -56,7 +56,7 @@ cpos = [
 
 top.plot(cpos=cpos, color=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/exercises/d_contouring.py
+++ b/tutorial/04_filters/exercises/d_contouring.py
@@ -11,27 +11,27 @@ meshes can have 1D iso-lines of a scalar field extracted.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Iso-Lines
 # +++++++++
 #
 # Let's extract 1D iso-lines of a scalar field from a 2D surface mesh.
 mesh = examples.load_random_hills()
 
-###############################################################################
+# %%
 help(mesh.contour)
 
-###############################################################################
+# %%
 contours = ...
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh, opacity=0.85)
 p.add_mesh(contours, color="white", line_width=5)
 p.show()
 
 
-###############################################################################
+# %%
 # Iso-Surfaces
 # ++++++++++++
 #
@@ -40,13 +40,13 @@ p.show()
 mesh = examples.download_embryo()
 mesh
 
-###############################################################################
+# %%
 # For this example dataset, let's create 5 contour levels between the values
 # of 50 and 200
 
 contours = ...
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh.outline(), color="k")
 p.add_mesh(contours, opacity=0.25, clim=[0, 200])
@@ -57,7 +57,7 @@ p.camera_position = [
 ]
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/exercises/e_glyphs.py
+++ b/tutorial/04_filters/exercises/e_glyphs.py
@@ -9,15 +9,15 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Example dataset with normals
 mesh = examples.load_random_hills()
 
-###############################################################################
+# %%
 # Glyphying can be done via the :func:`pyvista.DataSetFilters.glyph` filter
 help(mesh.glyph)
 
-###############################################################################
+# %%
 # Sometimes you might not want glyphs for every node in the input dataset. In
 # this case, you can choose to build glyphs for a subset of the input dataset
 # by using a merging tolerance. Here we specify a merging tolerance of five
@@ -27,13 +27,13 @@ help(mesh.glyph)
 arrows = ...
 
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(arrows, color="black")
 p.add_mesh(mesh, scalars="Elevation", cmap="terrain", smooth_shading=True)
 p.show()
 
-###############################################################################
+# %%
 # A common approach is to load vectors directly to the mesh object and then
 # access the :attr:`pyvista.DataSet.arrows` property to produce glyphs.
 
@@ -50,7 +50,7 @@ vectors = np.vstack(
 vectors
 
 
-###############################################################################
+# %%
 
 # add and scale
 sphere["vectors"] = vectors * 0.3
@@ -59,14 +59,14 @@ sphere.set_active_vectors("vectors")
 # plot just the arrows
 sphere.arrows.plot()
 
-###############################################################################
+# %%
 # Plot the arrows and the sphere.
 p = pv.Plotter()
 p.add_mesh(sphere.arrows, lighting=False, scalar_bar_args={"title": "Vector Magnitude"})
 p.add_mesh(sphere, color="grey", ambient=0.6, opacity=0.5, show_edges=False)
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/solutions/b_clipping.py
+++ b/tutorial/04_filters/solutions/b_clipping.py
@@ -11,7 +11,7 @@ Clip/cut any dataset using using planes or boxes.
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Clip with Plane
 # +++++++++++++++
 #
@@ -20,15 +20,15 @@ from pyvista import examples
 dataset = examples.download_bunny_coarse()
 dataset
 
-###############################################################################
+# %%
 help(dataset.clip)
 
-###############################################################################
+# %%
 # Perform a clip with a Y axis normal
 clipped = dataset.clip("y", invert=False)
 clipped
 
-###############################################################################
+# %%
 # Plot the result.
 p = pv.Plotter()
 p.add_mesh(dataset, style="wireframe", color="blue", label="Input")
@@ -38,7 +38,7 @@ p.camera_position = [(0.24, 0.32, 0.7), (0.02, 0.03, -0.02), (-0.12, 0.93, -0.34
 p.show()
 
 
-###############################################################################
+# %%
 # Clip with Bounds
 # ++++++++++++++++
 #
@@ -48,17 +48,17 @@ p.show()
 # First, download an example dataset.
 dataset = examples.download_office()
 
-###############################################################################
+# %%
 help(dataset.clip_box)
 
-###############################################################################
+# %%
 # Clip the dataset with a bounding box defined by the values in ``bounds``
 # ``(xmin, xmax, ymin, ymax, zmin, zmax)``
 bounds = [2, 4.5, 2, 4.5, 1, 3]
 clipped = dataset.clip_box(bounds)
 clipped
 
-###############################################################################
+# %%
 # Plot the original dataset and the clipped one.
 p = pv.Plotter()
 p.add_mesh(dataset, style="wireframe", color="blue", label="Input")
@@ -67,7 +67,7 @@ p.add_legend()
 p.show()
 
 
-###############################################################################
+# %%
 # Clip with Rotated Box
 # +++++++++++++++++++++
 #
@@ -84,7 +84,7 @@ p.add_mesh(roi, opacity=0.75, color="red")
 p.add_mesh(mesh, opacity=0.5)
 p.show()
 
-###############################################################################
+# %%
 # Run the box clipping algorithm with the defined box geometry.
 extracted = mesh.clip_box(roi, invert=False)
 
@@ -98,7 +98,7 @@ p.link_views()
 p.view_isometric()
 p.show()
 
-###############################################################################
+# %%
 # Crinkled Clipping
 # +++++++++++++++++
 # Crinkled clipping is useful if you don't want the clip filter to truly clip
@@ -113,20 +113,20 @@ p.show()
 # Input mesh
 mesh = pv.Wavelet()
 
-###############################################################################
+# %%
 # Define clipping plane
 normal = (1, 1, 1)
 plane = pv.Plane(i_size=30, j_size=30, direction=normal)
 
-###############################################################################
+# %%
 # Perform a standard clip
 clipped = mesh.clip(normal=normal)
 
-###############################################################################
+# %%
 # Perform a crinkled clip to compare
 crinkled = mesh.clip(normal=normal, crinkle=True)
 
-###############################################################################
+# %%
 # Plot comparison
 p = pv.Plotter(shape=(1, 2))
 p.add_mesh(clipped, show_edges=True)
@@ -137,7 +137,7 @@ p.add_mesh(plane.extract_feature_edges(), color="r")
 p.link_views()
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/solutions/c_compute-normals.py
+++ b/tutorial/04_filters/solutions/c_compute-normals.py
@@ -16,7 +16,7 @@ from pyvista import examples
 mesh = examples.download_topo_global()
 mesh.plot(cmap="gist_earth", show_scalar_bar=False)
 
-###############################################################################
+# %%
 # Now we have a surface dataset of the globe loaded - unfortunately, the
 # dataset shows the globe with a uniform radius which hides topographic relief.
 # Using :func:`pyvista.PolyData.compute_normals`, we can compute the normal
@@ -27,16 +27,16 @@ mesh.plot(cmap="gist_earth", show_scalar_bar=False)
 # Compute the normals in-place and use them to warp the globe
 mesh.compute_normals(inplace=True)  # this activates the normals as well
 
-###############################################################################
+# %%
 # Now use those normals to warp the surface
 warp = mesh.warp_by_scalar(factor=0.5e-5)
 
-###############################################################################
+# %%
 # And let's see it!
 warp.plot(cmap="gist_earth", show_scalar_bar=False)
 
 
-###############################################################################
+# %%
 # We could also use face or cell normals to extract all the faces of a mesh
 # facing a general direction. In the following snippet, we take a mesh, compute
 # the normals along its cell faces, and extract the faces that face upward.
@@ -59,7 +59,7 @@ cpos = [
 
 top.plot(cpos=cpos, color=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/solutions/d_contouring.py
+++ b/tutorial/04_filters/solutions/d_contouring.py
@@ -14,27 +14,27 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Iso-Lines
 # +++++++++
 #
 # Let's extract 1D iso-lines of a scalar field from a 2D surface mesh.
 mesh = examples.load_random_hills()
 
-###############################################################################
+# %%
 help(mesh.contour)
 
-###############################################################################
+# %%
 contours = mesh.contour()
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh, opacity=0.85)
 p.add_mesh(contours, color="white", line_width=5)
 p.show()
 
 
-###############################################################################
+# %%
 # Iso-Surfaces
 # ++++++++++++
 #
@@ -43,13 +43,13 @@ p.show()
 mesh = examples.download_embryo()
 mesh
 
-###############################################################################
+# %%
 # For this example dataset, let's create 5 contour levels between the values
 # of 50 and 200
 
 contours = mesh.contour(np.linspace(50, 200, 5))
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh.outline(), color="k")
 p.add_mesh(contours, opacity=0.25, clim=[0, 200])
@@ -60,7 +60,7 @@ p.camera_position = [
 ]
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/04_filters/solutions/e_glyphs.py
+++ b/tutorial/04_filters/solutions/e_glyphs.py
@@ -11,15 +11,15 @@ import numpy as np
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # Example dataset with normals
 mesh = examples.load_random_hills()
 
-###############################################################################
+# %%
 # Glyphying can be done via the :func:`pyvista.DataSetFilters.glyph` filter
 help(mesh.glyph)
 
-###############################################################################
+# %%
 # Sometimes you might not want glyphs for every node in the input dataset. In
 # this case, you can choose to build glyphs for a subset of the input dataset
 # by using a merging tolerance. Here we specify a merging tolerance of five
@@ -29,13 +29,13 @@ help(mesh.glyph)
 arrows = mesh.glyph(scale="Normals", orient="Normals", tolerance=0.05)
 
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(arrows, color="black")
 p.add_mesh(mesh, scalars="Elevation", cmap="terrain", smooth_shading=True)
 p.show()
 
-###############################################################################
+# %%
 # A common approach is to load vectors directly to the mesh object and then
 # access the :attr:`pyvista.DataSet.arrows` property to produce glyphs.
 
@@ -52,7 +52,7 @@ vectors = np.vstack(
 vectors
 
 
-###############################################################################
+# %%
 
 # add and scale
 sphere["vectors"] = vectors * 0.3
@@ -61,14 +61,14 @@ sphere.set_active_vectors("vectors")
 # plot just the arrows
 sphere.arrows.plot()
 
-###############################################################################
+# %%
 # Plot the arrows and the sphere.
 p = pv.Plotter()
 p.add_mesh(sphere.arrows, lighting=False, scalar_bar_args={"title": "Vector Magnitude"})
 p.add_mesh(sphere, color="grey", ambient=0.6, opacity=0.5, show_edges=False)
 p.show()
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/06_vtk/a_1_transition_vtk.py
+++ b/tutorial/06_vtk/a_1_transition_vtk.py
@@ -17,7 +17,7 @@ from math import cos, sin
 
 import vtk
 
-###############################################################################
+# %%
 # Create values for a 300x300 image dataset
 #
 # In our example, we want to have values from the function
@@ -34,18 +34,18 @@ for x in range(300):
     for y in range(300):
         values.SetValue(x * 300 + y, 127.5 + (1.0 + sin(x / 25.0) * cos(y / 25.0)))
 
-###############################################################################
+# %%
 # Create the image structure
 image_data = vtk.vtkImageData()
 image_data.SetOrigin(0, 0, 0)
 image_data.SetSpacing(1, 1, 1)
 image_data.SetDimensions(300, 300, 1)
 
-###############################################################################
+# %%
 # Assign the values to the image
 image_data.GetPointData().SetScalars(values)
 
-###############################################################################
+# %%
 # As you can see, there is quite a bit of boilerplate that goes into
 # the creation of a simple :vtk:`vtkImageData` dataset. PyVista provides
 # much more concise syntax that is more "Pythonic". The equivalent code in
@@ -54,7 +54,7 @@ image_data.GetPointData().SetScalars(values)
 import numpy as np
 import pyvista as pv
 
-###############################################################################
+# %%
 # Use the meshgrid function to create 2D "grids" of the x and y values.
 # This section effectively replaces the vtkDoubleArray.
 
@@ -62,13 +62,13 @@ xi = np.arange(300)
 x, y = np.meshgrid(xi, xi)
 values = 127.5 + (1.0 + np.sin(x / 25.0) * np.cos(y / 25.0))
 
-###############################################################################
+# %%
 # Create the grid.  Note how the values must use Fortran ordering.
 
 grid = pv.ImageData(dimensions=(300, 300, 1))
 grid.point_data["values"] = values.flatten(order="F")
 
-###############################################################################
+# %%
 # Here, PyVista has done several things for us:
 #
 # #. PyVista combines the dimensionality of the data (in the shape of
@@ -128,13 +128,13 @@ grid.point_data["values"] = values.flatten(order="F")
 #     renWin.Render()
 #     iren.Start()
 
-###############################################################################
+# %%
 # However, with PyVista you only need:
 
 grid.plot(cpos="xy", show_scalar_bar=False, cmap="coolwarm")
 
 
-###############################################################################
+# %%
 # PointSet Construction
 # ^^^^^^^^^^^^^^^^^^^^^
 # PyVista heavily relies on NumPy to efficiently allocate and access
@@ -157,12 +157,12 @@ vtk_array.SetValue(8, 0)
 vtk_points = vtk.vtkPoints()
 vtk_points.SetData(vtk_array)
 
-###############################################################################
+# %%
 # To do the same within PyVista, you simply need to create a NumPy array:
 
 np_points = np.array([[0, 0, 0], [1, 0, 0], [0.5, 0.667, 0]])
 
-###############################################################################
+# %%
 # .. note::
 #    You can use :func:`pyvista.vtk_points` to construct a :vtk:`vtkPoints`
 #    object, but this is unnecessary in almost all situations.
@@ -174,13 +174,13 @@ np_points = np.array([[0, 0, 0], [1, 0, 0], [0.5, 0.667, 0]])
 
 poly_data = pv.PolyData(np_points)
 
-###############################################################################
+# %%
 # Whereas in VTK you would have to do:
 
 vtk_poly_data = vtk.vtkPolyData()
 vtk_poly_data.SetPoints(vtk_points)
 
-###############################################################################
+# %%
 # The same goes with assigning face or cell connectivity/topology.  With
 # VTK you would normally have to loop using :func:`InsertNextCell` and
 # :func:`InsertCellPoint`.  For example, to create a single cell
@@ -193,7 +193,7 @@ cell_arr.InsertCellPoint(1)
 cell_arr.InsertCellPoint(2)
 vtk_poly_data.SetPolys(cell_arr)
 
-###############################################################################
+# %%
 # In PyVista, we can assign this directly in the constructor and then
 # access it (or change it) from the :attr:`faces
 # <pyvista.PolyData.faces>` attribute.
@@ -203,7 +203,7 @@ poly_data = pv.PolyData(np_points, faces)
 poly_data.faces
 
 
-###############################################################################
+# %%
 # PyVista Tradeoffs
 # ~~~~~~~~~~~~~~~~~
 # While most features can, not everything can be simplified in PyVista without
@@ -218,7 +218,7 @@ mesh_a = pv.Sphere()
 mesh_b = pv.Sphere(center=(-0.4, 0, 0))
 out, n_coll = mesh_a.collision(mesh_b, generate_scalars=True, contact_mode=2)
 
-###############################################################################
+# %%
 
 pl = pv.Plotter()
 pl.add_mesh(out)
@@ -226,7 +226,7 @@ pl.add_mesh(mesh_b, style="wireframe", color="k")
 pl.camera_position = "xy"
 pl.show()
 
-###############################################################################
+# %%
 # Under the hood, the collision filter detects mesh collisions using
 # oriented bounding box (OBB) trees.  For a single collision, this filter
 # is as performant as the VTK counterpart, but when computing multiple
@@ -237,7 +237,7 @@ pl.show()
 # PyVista is sufficient for most data science, but there are times when
 # you may want to use VTK classes directly.
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/06_vtk/a_2_pyvista_vtk.py
+++ b/tutorial/06_vtk/a_2_pyvista_vtk.py
@@ -17,7 +17,7 @@ import pyvista as pv
 import vtk
 from pyvista import examples
 
-###############################################################################
+# %%
 # Create a circle using vtk
 polygonSource = vtk.vtkRegularPolygonSource()  # noqa: N816
 polygonSource.GeneratePolygonOff()
@@ -26,12 +26,12 @@ polygonSource.SetRadius(5.0)
 polygonSource.SetCenter(0.0, 0.0, 0.0)
 polygonSource.Update()
 
-###############################################################################
+# %%
 # wrap and plot using pyvista
 mesh = pv.wrap(polygonSource.GetOutput())
 mesh.plot(line_width=3, cpos="xy", color="k")
 
-###############################################################################
+# %%
 # In this manner, you can get the "best of both worlds" should you need
 # the flexibility of PyVista and the raw power of VTK.
 #
@@ -39,7 +39,7 @@ mesh.plot(line_width=3, cpos="xy", color="k")
 #    You can use :func:`pyvista.Polygon` for a one line replacement of
 #    the above VTK code.
 
-###############################################################################
+# %%
 # VTK Algorithms
 # ~~~~~~~~~~~~~~
 #
@@ -47,15 +47,15 @@ mesh.plot(line_width=3, cpos="xy", color="k")
 
 mesh = examples.download_bunny_coarse()
 
-###############################################################################
+# %%
 # Initialize VTK algorithm
 splatter = vtk.vtkGaussianSplatter()
 
-###############################################################################
+# %%
 # Pass PyVista object as input to VTK
 splatter.SetInputData(mesh)
 
-###############################################################################
+# %%
 # Set parameters
 n = 200
 splatter.SetSampleDimensions(n, n, n)
@@ -64,27 +64,27 @@ splatter.SetExponentFactor(-10)
 splatter.SetEccentricity(2)
 splatter.Update()
 
-###############################################################################
+# %%
 # Retrieve output and wrap with PyVista
 vol = pv.wrap(splatter.GetOutput())
 
-###############################################################################
+# %%
 # Use PyVista to produce contours
 cntrs = vol.contour([0.95 * splatter.GetRadius()])
 
-###############################################################################
+# %%
 # Use PyVista to plot
 p = pv.Plotter()
 p.add_mesh(mesh, style="wireframe")
 p.add_mesh(cntrs, color=True)
 p.show()
 
-###############################################################################
+# %%
 # .. note::
 #
 #     The above example was adapted from VTK's `Embed Points Into Volume <https://kitware.github.io/vtk-examples/site/Cxx/PolyData/EmbedPointsIntoVolume/>`_
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/06_vtk/b_create_vtk.py
+++ b/tutorial/06_vtk/b_create_vtk.py
@@ -14,7 +14,7 @@ try:
 except:  # noqa: E722
     from vtk.util.numpy_support import numpy_to_vtk
 
-###############################################################################
+# %%
 # Create ``vtkImageData``
 # ^^^^^^^^^^^^^^^^^^^^^^^
 image = vtk.vtkImageData()
@@ -22,7 +22,7 @@ image.SetDimensions(10, 10, 2)
 image.SetSpacing(1, 2, 5)
 image.SetOrigin(-0.5, -3, 0)
 
-###############################################################################
+# %%
 # Add point data
 values = np.arange(np.prod(image.GetDimensions()))
 # Convert numpy array to VTK array
@@ -31,11 +31,11 @@ arr.SetName("values")  # CRITICAL
 image.GetPointData().SetScalars(arr)
 image
 
-###############################################################################
+# %%
 # Plot with PyVista for simplicity
 pv.plot(image, show_edges=True)
 
-###############################################################################
+# %%
 # Create ``vtkStructuredGrid``
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -59,18 +59,18 @@ grid.SetDimensions(*z.shape, 1)
 grid.SetPoints(points)
 grid
 
-###############################################################################
+# %%
 # Add point data
 arr = numpy_to_vtk(z.ravel())
 arr.SetName("z")  # CRITICAL
 grid.GetPointData().SetScalars(arr)
 
 
-###############################################################################
+# %%
 # Plot with PyVista for simplicity
 pv.plot(grid, show_edges=True)
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/06_vtk/c_vtk_algorithms.py
+++ b/tutorial/06_vtk/c_vtk_algorithms.py
@@ -19,21 +19,21 @@ import pyvista as pv
 import vtk
 from pyvista import examples
 
-###############################################################################
+# %%
 # Here is a sample mesh
 mesh = examples.load_random_hills()
 mesh
 
-###############################################################################
+# %%
 mesh.plot()
 
-###############################################################################
+# %%
 # Simple Filter
 # ^^^^^^^^^^^^^
 # Let's start out with a simple VTK filter: ``vtkOutlineFilter``
 help(vtk.vtkOutlineFilter)
 
-###############################################################################
+# %%
 # Try using this VTK filter yourself here:
 #
 # Remember that you will have to wrap the output of the algorithm with :func:`pyvista.wrap`
@@ -44,7 +44,7 @@ alg = vtk.vtkOutlineFilter()
 outline = pv.wrap(alg.GetOutput())
 outline
 
-###############################################################################
+# %%
 alg.SetInputDataObject(mesh)
 alg.SetGenerateFaces(False)  # noqa: FBT003
 alg.Update()
@@ -52,19 +52,19 @@ alg.Update()
 outline = pv.wrap(alg.GetOutput())
 outline
 
-###############################################################################
+# %%
 # .. note::
 #
 #   Note that the about filter can be replaced with a ``.outline()`` filter in PyVista
 
-###############################################################################
+# %%
 p = pv.Plotter()
 p.add_mesh(mesh)
 p.add_mesh(outline, color="k")
 p.show()
 
 
-###############################################################################
+# %%
 # Find your own filter
 # ^^^^^^^^^^^^^^^^^^^^
 #
@@ -73,7 +73,7 @@ p.show()
 #
 # See https://kitware.github.io/vtk-examples/site/Python/
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/06_vtk/d_wasm.py
+++ b/tutorial/06_vtk/d_wasm.py
@@ -30,7 +30,7 @@ from vtkmodules.vtkRenderingCore import (
     vtkRenderWindowInteractor,
 )
 
-###############################################################################
+# %%
 
 
 def setup_vtk():  # noqa: PLR0915
@@ -118,7 +118,7 @@ def setup_vtk():  # noqa: PLR0915
     return renWin, ren, cs2, ss
 
 
-###############################################################################
+# %%
 
 
 @TrameApp()
@@ -187,16 +187,16 @@ class App:
             return layout
 
 
-###############################################################################
+# %%
 app = App("wasm")
 await app.ui.ready
 
-###############################################################################
+# %%
 # Make sure to give room for the download of WASM bundle
 # Only needed at first execution
 import asyncio
 
 await asyncio.sleep(1)
 
-###############################################################################
+# %%
 app.ui

--- a/tutorial/06_vtk/e_vtk_next.py
+++ b/tutorial/06_vtk/e_vtk_next.py
@@ -92,7 +92,7 @@ light_kit.AddLightsToRenderer(renderer)
 
 import pathlib
 
-###############################################################################
+# %%
 # Load input mesh from a vtkPartitionedDataSetCollection file
 from vtkmodules.vtkIOXML import vtkXMLPartitionedDataSetCollectionReader
 
@@ -109,11 +109,11 @@ actor.mapper = (reactor >> vtkCompositePolyDataMapper()).last
 actor.property.opacity = 0.2
 renderer.AddActor(actor)
 
-###############################################################################
+# %%
 # Construct magpy coil objects for each coil in the reactor mesh.
 coils = build_magnetic_coils(reactor, current=1000)
 
-###############################################################################
+# %%
 # Compute B, H in a 32x32x32 grid
 
 grid = vtkImageData(extent=(-16, 16, -16, 16, -16, 16), spacing=(0.1, 0.1, 0.1))
@@ -123,12 +123,12 @@ grid.point_data.set_array("B (mT)", b)
 h = coils.getH(grid_points)
 grid.point_data.set_array("H (A/m)", h)
 
-###############################################################################
+# %%
 # Show coils
 magpy.show(coils, arrow=True)
 save_dataset(grid, "data/solution.vti")
 
-###############################################################################
+# %%
 # Compute streamlines of B field induced by toroidal coils.
 trace_streamlines = vtkStreamTracer(
     integrator_type=vtkStreamTracer.RUNGE_KUTTA45,
@@ -143,7 +143,7 @@ create_sphere = vtkSphereSource(theta_resolution=16)
 grid >> select_ports(0, trace_streamlines)
 create_sphere >> select_ports(1, trace_streamlines)
 
-###############################################################################
+# %%
 # Visualize streamlines
 from vtkmodules.vtkFiltersCore import vtkTubeFilter
 
@@ -153,7 +153,7 @@ actor.mapper = (
 ).last
 renderer.AddActor(actor)
 
-###############################################################################
+# %%
 # Animate the disk position such that it oscillates between y=-1 and y=1.
 from itertools import cycle
 
@@ -172,7 +172,7 @@ class vtkTimerCallback:  # noqa: N801
         self.window.Render()
 
 
-###############################################################################
+# %%
 # Sign up to receive TimerEvent
 
 cb = vtkTimerCallback(create_sphere, window, nsteps=250)

--- a/tutorial/08_widgets/a_box-widget.py
+++ b/tutorial/08_widgets/a_box-widget.py
@@ -24,18 +24,18 @@ from pyvista import examples
 
 mesh = examples.download_nefertiti()
 
-###############################################################################
+# %%
 
 p = pv.Plotter()
 p.add_mesh_clip_box(mesh, color="white")
 p.show(cpos=[-1, -1, 0.2])
 
 
-###############################################################################
+# %%
 # After interacting with the scene, the clipped mesh is available as:
 p.box_clipped_meshes
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/b_checkbox-widget.py
+++ b/tutorial/08_widgets/b_checkbox-widget.py
@@ -13,7 +13,7 @@ See :func:`pyvista.Plotter.add_checkbox_button_widget` for more details.
 # sphinx_gallery_thumbnail_number = 2
 import pyvista as pv
 
-###############################################################################
+# %%
 # Single Checkbox
 # +++++++++++++++
 
@@ -30,12 +30,12 @@ def toggle_vis(flag) -> None:
 p.add_checkbox_button_widget(toggle_vis, value=True)
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/single-checkbox-widget.gif
 
-###############################################################################
+# %%
 # Multiple Checkboxes
 # +++++++++++++++++++
 #
@@ -62,7 +62,7 @@ class SetVisibilityCallback:
         self.actor.SetVisibility(state)
 
 
-###############################################################################
+# %%
 
 # Widget size
 size = 50
@@ -89,12 +89,12 @@ for i, lst in enumerate(colors):
 
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/multiple-checkbox-widget.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/c_line-widget.py
+++ b/tutorial/08_widgets/c_line-widget.py
@@ -27,7 +27,7 @@ furniture = examples.download_kitchen(split=True)
 arr = np.linalg.norm(mesh["velocity"], axis=1)
 clim = [arr.min(), arr.max()]
 
-###############################################################################
+# %%
 
 p = pv.Plotter()
 p.add_mesh(furniture, name="furniture", color=True)
@@ -45,12 +45,12 @@ def simulate(pointa, pointb) -> None:
 p.add_line_widget(callback=simulate, use_vertices=True)
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/line-widget-streamlines.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/d_multi-slider-widget.py
+++ b/tutorial/08_widgets/d_multi-slider-widget.py
@@ -34,12 +34,12 @@ class MyCustomRoutine:
         self.output.copy_from(result)
 
 
-###############################################################################
+# %%
 
 starting_mesh = pv.Sphere()
 engine = MyCustomRoutine(starting_mesh)
 
-###############################################################################
+# %%
 
 p = pv.Plotter()
 p.add_mesh(starting_mesh, show_edges=True)
@@ -72,12 +72,12 @@ p.add_slider_widget(
 )
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/multiple-slider-widget.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/e_plane-widget.py
+++ b/tutorial/08_widgets/e_plane-widget.py
@@ -24,31 +24,31 @@ p = pv.Plotter()
 p.add_mesh_clip_plane(vol)
 p.show()
 
-###############################################################################
+# %%
 # After interacting with the scene, the clipped mesh is available as:
 p.plane_clipped_meshes
 
-###############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/plane-clip.gif
 
-###############################################################################
+# %%
 # Or you could slice a mesh using the plane widget:
 
 p = pv.Plotter()
 p.add_mesh_slice(vol)
 p.show()
-###############################################################################
+# %%
 # After interacting with the scene, the slice is available as:
 p.plane_sliced_meshes
 
-###############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/plane-slice.gif
 
-###############################################################################
+# %%
 # Or you could leverage the plane widget for some custom task like glyphing a
 # vector field along that plane. Note that we have to pass a ``name`` when
 # calling ``add_mesh`` to ensure that there is only one set of glyphs plotted
@@ -74,13 +74,13 @@ p.show_grid()
 p.add_axes()
 p.show()
 
-###############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/plane-glyph.gif
 
 
-###############################################################################
+# %%
 # Further, a user can disable the arrow vector by setting the
 # ``normal_rotation`` argument to ``False``. For example, here we
 # programmatically set the normal vector on which we want to translate the
@@ -90,7 +90,7 @@ p = pv.Plotter()
 p.add_mesh_slice(vol, normal=(1, 1, 1), normal_rotation=False)
 p.show()
 
-###############################################################################
+# %%
 # The vector is also forcibly disabled anytime the ``assign_to_axis`` argument
 # is set.
 p = pv.Plotter()
@@ -98,7 +98,7 @@ p.add_mesh_slice(vol, assign_to_axis="z")
 p.show()
 
 
-###############################################################################
+# %%
 # Additionally, users can modify the interaction event that triggers the
 # callback functions handled by the different plane widget helpers through the
 # ``interaction_event`` keyword argument when available. For example,
@@ -109,13 +109,13 @@ p = pv.Plotter()
 p.add_mesh_slice(vol, assign_to_axis="z", interaction_event=vtk.vtkCommand.InteractionEvent)
 p.show()
 
-###############################################################################
+# %%
 # And here is a screen capture of a user interacting with this continuously via
 # the ``InteractionEvent`` observer:
 #
 # .. image:: ../../images/gifs/plane-slice-continuous.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/f_slider-bar-widget.py
+++ b/tutorial/08_widgets/f_slider-bar-widget.py
@@ -13,7 +13,7 @@ be used for just about anything.
 
 # sphinx_gallery_thumbnail_number = 1
 
-##############################################################################
+# %%
 # One helper method we've added is the
 # :func:`pyvista.Plotter.add_mesh_threshold` method which leverages the
 # slider widget to control a thresholding value.
@@ -27,16 +27,16 @@ p = pv.Plotter()
 p.add_mesh_threshold(mesh)
 p.show()
 
-###############################################################################
+# %%
 # After interacting with the scene, the threshold mesh is available as:
 p.threshold_meshes
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/slider-widget-threshold.gif
 
-###############################################################################
+# %%
 # Custom Callback
 # +++++++++++++++
 #
@@ -56,12 +56,12 @@ def create_mesh(value) -> None:
 p.add_slider_widget(create_mesh, [5, 100], title="Resolution")
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/slider-widget-resolution.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/g_sphere-widget.py
+++ b/tutorial/08_widgets/g_sphere-widget.py
@@ -17,7 +17,7 @@ Let's look at a few use cases that all update a surface mesh.
 
 # sphinx_gallery_thumbnail_number = 3
 
-##############################################################################
+# %%
 # Example A
 # +++++++++
 #
@@ -50,13 +50,13 @@ p.add_mesh(surf, color=True)
 p.show_grid()
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/sphere-widget-a.gif
 
 
-###############################################################################
+# %%
 # Example B
 # +++++++++
 #
@@ -90,12 +90,12 @@ p.add_mesh(surf, color=True)
 p.show_grid()
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/sphere-widget-b.gif
 
-###############################################################################
+# %%
 # Example C
 # +++++++++
 #
@@ -145,7 +145,7 @@ def update_surface(point, i) -> None:
 # Get a list of unique colors for each widget
 colors = get_colors(len(points))
 
-##############################################################################
+# %%
 
 # Begin the plotting routine
 p = pv.Plotter()
@@ -161,12 +161,12 @@ p.show_grid()
 # Show it!
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/sphere-widget-c.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/08_widgets/h_spline-widget.py
+++ b/tutorial/08_widgets/h_spline-widget.py
@@ -18,7 +18,7 @@ path. To do this, we have added a convenient helper method which leverages the
 import numpy as np
 import pyvista as pv
 
-##############################################################################
+# %%
 
 mesh = pv.Wavelet()
 
@@ -39,12 +39,12 @@ p.add_mesh_slice_spline(mesh, initial_points=points, n_handles=5)
 p.camera_position = [(30, -42, 30), (0.0, 0.0, 0.0), (-0.09, 0.53, 0.84)]
 p.show()
 
-##############################################################################
+# %%
 # And here is a screen capture of a user interacting with this
 #
 # .. image:: ../../images/gifs/spline-widget.gif
 
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/a_getting_started.py
+++ b/tutorial/09_trame/a_getting_started.py
@@ -10,7 +10,7 @@ Getting started with PyVista and Trame
 import pyvista as pv
 from pyvista import examples
 
-###############################################################################
+# %%
 # PyVista's Jupyter backend is powered by **Trame**. So by default you are
 # using trame without knowing it.
 #
@@ -30,7 +30,7 @@ from pyvista import examples
 dataset = examples.download_lucy()
 dataset.plot(smooth_shading=True, color="white")
 
-###############################################################################
+# %%
 # Building applications with PyVista and Trame
 #
 # Now, let's build a simple application that updates the mesh color with the click of a button.

--- a/tutorial/09_trame/a_trame_simple.py
+++ b/tutorial/09_trame/a_trame_simple.py
@@ -31,7 +31,7 @@ with SinglePageLayout(server) as layout, layout.content:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/b_trame_actor_color.py
+++ b/tutorial/09_trame/b_trame_actor_color.py
@@ -59,7 +59,7 @@ with SinglePageLayout(server) as layout:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/c_trame_scalars.py
+++ b/tutorial/09_trame/c_trame_scalars.py
@@ -73,7 +73,7 @@ with SinglePageLayout(server) as layout:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/d_trame_scalar_range.py
+++ b/tutorial/09_trame/d_trame_scalar_range.py
@@ -57,7 +57,7 @@ with SinglePageLayout(server) as layout:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/e_trame_algorithm.py
+++ b/tutorial/09_trame/e_trame_algorithm.py
@@ -63,7 +63,7 @@ with SinglePageLayout(server) as layout:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>

--- a/tutorial/09_trame/f_trame_open_file.py
+++ b/tutorial/09_trame/f_trame_open_file.py
@@ -68,7 +68,7 @@ with SinglePageLayout(server) as layout:
 # Show UI
 await layout.ready
 layout
-###############################################################################
+# %%
 # .. raw:: html
 #
 #     <center>


### PR DESCRIPTION
## Summary
- Updates block splitter syntax from long lines of hash symbols to `# %%` 
- Aligns with sphinx-gallery documentation standards
- Improves compatibility with various Python development tools (VS Code, Jupytext, etc.)

## Motivation
This change follows the pattern established in https://github.com/pyvista/pyvista/pull/6378, which updated PyVista's example files to use the standardized `# %%` code cell separator syntax.

## Changes
- Replaced all instances of `###############################################################################` with `# %%` in tutorial Python files