### PR TITLE
Update VTK version requirement to >=9.3 in WASM example

### DIFF
--- a/tutorial/06_vtk/d_wasm.py
+++ b/tutorial/06_vtk/d_wasm.py
@@ -2,11 +2,11 @@
 VTK + WASM
 ~~~~~~~~~~
 
-Use WASM local rendering. This requires a pre-release version of VTK:
+Use WASM local rendering. This requires VTK version greater than 9.3:
 
 .. code-block:: bash
 
-    pip install --extra-index-url https://wheels.vtk.org vtk==9.3.20240629.dev0
+    pip install --extra-index-url https://wheels.vtk.org vtk>=9.3
 
 """
 


### PR DESCRIPTION
Updates the VTK version requirement from a specific dev version to >=9.3 in the WASM example.