### PR TITLE
Add Pixi installation option to getting started guide

### DIFF
--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -34,6 +34,12 @@ PyVista can be installed on several environments, including, but not limited to:
 
          conda install -c conda-forge pyvista jupyterlab trame trame-vuetify trame-vtk ipywidgets
 
+   .. tab-item:: pixi
+
+      .. code::
+
+         pixi add pyvista jupyterlab trame trame-vuetify trame-vtk ipywidgets
+
 
 
 


### PR DESCRIPTION
## Summary
- Added a new installation tab for Pixi package manager in the getting started guide
- Provides users with an alternative installation method alongside pip and conda

## Test plan
- [ ] Build the documentation locally to verify the new tab renders correctly
- [ ] Test the pixi installation command to ensure it works as expected
- [ ] Verify the formatting matches the existing pip and conda tabs

🤖 Generated with [Claude Code](https://claude.ai/code)