### PR TITLE
Fix CI: Update peaceiris/actions-gh-pages to working commit hash

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -131,7 +131,7 @@ jobs:
         run: find doc/build/mini18n-html -mindepth 1 -maxdepth 1 -type d -exec cp -rf {} doc/build/html/ \;
 
       - name: Deploy to GH Pages
-        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32
+        uses: peaceiris/actions-gh-pages@4b09552702d0b65573696410d4707c765da2630b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: doc/build/html
@@ -148,7 +148,7 @@ jobs:
           cp Dockerfile tutorial-content/
 
       - name: Deploy to Tutorial branch
-        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32
+        uses: peaceiris/actions-gh-pages@4b09552702d0b65573696410d4707c765da2630b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: tutorial-content/

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -131,7 +131,7 @@ jobs:
         run: find doc/build/mini18n-html -mindepth 1 -maxdepth 1 -type d -exec cp -rf {} doc/build/html/ \;
 
       - name: Deploy to GH Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3e66a12a2e531d2a7974b4e2762e08
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: doc/build/html
@@ -148,7 +148,7 @@ jobs:
           cp Dockerfile tutorial-content/
 
       - name: Deploy to Tutorial branch
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3e66a12a2e531d2a7974b4e2762e08
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: tutorial-content/


### PR DESCRIPTION
## 🐛 Fix CI Error

This PR fixes the failing "Build Documentation" workflow on the main branch.

### Problem
The CI was failing with the error:


### Solution
Updated both instances of the  action in  to use the latest working commit hash:

- **Before**:  (broken/inaccessible)
- **After**:  (latest from main branch)

### Changes Made
- Line 134: Updated "Deploy to GH Pages" step
- Line 151: Updated "Deploy to Tutorial branch" step

### Testing
The fix uses the latest commit from the peaceiris/actions-gh-pages main branch, which should resolve the accessibility issue.

Fixes the CI deployment failures on main branch.