### PR TITLE
Fix documentation typos and obsolete references

### DIFF
--- a/tutorial/02_mesh/README.rst
+++ b/tutorial/02_mesh/README.rst
@@ -238,11 +238,6 @@ Note how this varies from assigning scalars to each point
    pl.add_mesh(other_cube, cmap='coolwarm')
    pl.show()
 
-.. note::
-   We use :func:`pyvista.PolyDataFilters.clean` to merge the faces of
-   the cube since, by default, the cube is created with unmerged faces
-   and duplicate points.
-
 
 Exercises
 ---------

--- a/tutorial/02_mesh/exercises/e_read-file.py
+++ b/tutorial/02_mesh/exercises/e_read-file.py
@@ -28,7 +28,7 @@ help(pv.read)
 # extensions are listed in an internal function:
 #
 # See https://docs.pyvista.org/api/readers/_autosummary/pyvista.get_reader#pyvista.get_reader
-help(pv.core.utilities.reader.get_reader)
+help(pv.get_reader)
 
 
 # %%

--- a/tutorial/02_mesh/solutions/e_read-file.py
+++ b/tutorial/02_mesh/solutions/e_read-file.py
@@ -26,7 +26,7 @@ help(pv.read)
 # %%
 # PyVista supports a wide variety of file formats. The supported file
 # extensions are listed in an internal function:
-help(pv.core.utilities.reader.get_reader)
+help(pv.get_reader)
 
 
 # %%

--- a/tutorial/04_filters/exercises/b_clipping.py
+++ b/tutorial/04_filters/exercises/b_clipping.py
@@ -105,7 +105,7 @@ pl.show()
 #
 # This option is available for :func:`pyvista.DataSetFilters.clip`,
 # :func:`pyvista.DataSetFilters.clip_box`, and
-# :func:`pyvista.DataSetFilters.clip_sruface`, but not available when clipping
+# :func:`pyvista.DataSetFilters.clip_surface`, but not available when clipping
 # by scalar in :func:`pyvista.DataSetFilters.clip_scalar`.
 
 # Input mesh

--- a/tutorial/04_filters/solutions/b_clipping.py
+++ b/tutorial/04_filters/solutions/b_clipping.py
@@ -107,7 +107,7 @@ pl.show()
 #
 # This option is available for :func:`pyvista.DataSetFilters.clip`,
 # :func:`pyvista.DataSetFilters.clip_box`, and
-# :func:`pyvista.DataSetFilters.clip_sruface`, but not available when clipping
+# :func:`pyvista.DataSetFilters.clip_surface`, but not available when clipping
 # by scalar in :func:`pyvista.DataSetFilters.clip_scalar`.
 
 # Input mesh


### PR DESCRIPTION
Fixes the tutorial items reported in pyvista/pyvista#8709:

- `clip_sruface` -> `clip_surface` in the clipping exercise and solution.
- `pv.core.utilities.reader.get_reader` -> `pv.get_reader` in the read-file exercise and solution.
- Removed the note about `pv.Cube()` producing unmerged faces and duplicate points. `pv.Cube()` now returns 8 merged points by default, and the example never called `clean()`, so the note was both obsolete and inconsistent with the code.